### PR TITLE
feat: Add Ollama as an LLM provider

### DIFF
--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -116,6 +116,9 @@ class Configuration:
     OPENROUTER_API_BASE: Optional[str] = "https://openrouter.ai/api/v1"
     OR_SITE_URL: Optional[str] = "https://kortix.ai"
     OR_APP_NAME: Optional[str] = "Kortix AI"    
+
+    # Ollama configuration
+    OLLAMA_API_BASE: Optional[str] = "http://localhost:11434"
     
     # AWS Bedrock credentials
     AWS_ACCESS_KEY_ID: Optional[str] = None
@@ -190,6 +193,10 @@ class Configuration:
         
         # Load configuration from environment variables
         self._load_from_env()
+
+        # Special handling for OLLAMA_API_BASE default
+        if not os.getenv("OLLAMA_API_BASE") and hasattr(self, "OLLAMA_API_BASE"):
+            logger.info(f"OLLAMA_API_BASE not set, using default: {self.OLLAMA_API_BASE}")
         
         # Perform validation
         self._validate()


### PR DESCRIPTION
This commit introduces support for Ollama as a new LLM provider, allowing you to leverage locally running Ollama models.

Backend changes:
- Modified `backend/services/llm.py` and `backend/utils/config.py`.
- Added `OLLAMA` to the list of providers in `setup_api_keys()`.
- Updated `prepare_params()` to set the `api_base` for Ollama models using the `OLLAMA_API_BASE` environment variable (defaults to `http://localhost:11434`).
- Added logging for Ollama configuration.

Frontend changes:
- Updated `frontend/src/components/thread/chat-input/_use-model-selection.ts`.
- Added predefined Ollama models (e.g., `ollama_chat/llama3.1`, `ollama_chat/mistral`) to the `MODELS` constant for easier selection in local mode. These are categorized under `tier: 'custom'`.
- Ensured custom Ollama models added via the UI are correctly handled.

This allows you, when running the application in local mode, to select predefined Ollama models or add your own Ollama models through the custom model interface.