### PR TITLE
Fix: Handle undefined model metadata for custom models in frontend

### DIFF
--- a/frontend/src/components/thread/chat-input/_use-model-selection.ts
+++ b/frontend/src/components/thread/chat-input/_use-model-selection.ts
@@ -340,17 +340,17 @@ export const useModelSelection = () => {
     // Add custom models if in local mode
     if (isLocalMode()) {
       const customModelOptions = customModels.map(model => {
-        const modelData = MODELS[model.id as keyof typeof MODELS] || {}; // Get data if it's a predefined custom/Ollama model
+        const customModelEntry = MODELS[model.id as keyof typeof MODELS]; // This can be undefined
         return {
           id: model.id,
           label: model.label || formatModelName(model.id),
-          requiresSubscription: false, // Custom models don't require subscription
-          description: modelData.description || MODEL_TIERS.custom.baseDescription,
+          requiresSubscription: false,
+          description: customModelEntry?.description || MODEL_TIERS.custom.baseDescription,
           top: false,
           isCustom: true,
-          priority: modelData.priority || 30, // Use predefined priority or default
-          lowQuality: modelData.lowQuality || false,
-          recommended: modelData.recommended || false,
+          priority: customModelEntry?.priority || 30,
+          lowQuality: customModelEntry?.lowQuality || false,
+          recommended: customModelEntry?.recommended || false,
         };
       });
 


### PR DESCRIPTION
Corrects a TypeScript type error in `frontend/src/components/thread/chat-input/_use-model-selection.ts`. The error `Property 'description' does not exist on type '{}'` occurred when processing custom models whose IDs were not found in the predefined `MODELS` constant. In such cases, `modelData` would become an empty object, and accessing properties like `description` directly would cause a type error.

This commit resolves the issue by:
1. Assigning the result of `MODELS[model.id]` to `customModelEntry`, which can be `undefined`.
2. Using optional chaining (`customModelEntry?.description`, `customModelEntry?.priority`, etc.) when accessing properties from `customModelEntry`.

This ensures that if a custom model ID is not found in `MODELS`, these properties safely evaluate to `undefined`, allowing the existing fallback logic (e.g., `|| MODEL_TIERS.custom.baseDescription`) to apply correctly without causing a type error.

This fix should prevent the frontend build from failing due to this specific issue.