### PR TITLE
Refactor: Rename SUNA to MITOSIS in user-facing frontend

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
     template: `%s - ${siteConfig.name}`,
   },
   description:
-    'Suna is a fully open source AI assistant that helps you accomplish real-world tasks with ease. Through natural conversation, Suna becomes your digital companion for research, data analysis, and everyday challenges.',
+    'MITOSIS is a fully open source AI assistant that helps you accomplish real-world tasks with ease. Through natural conversation, MITOSIS becomes your digital companion for research, data analysis, and everyday challenges.',
   keywords: [
     'AI',
     'artificial intelligence',
@@ -43,13 +43,13 @@ export const metadata: Metadata = {
     'research',
     'data analysis',
   ],
-  authors: [{ name: 'Kortix Team', url: 'https://suna.so' }],
+  authors: [{ name: 'Kortix Team', url: 'https://mitosis.so' }],
   creator:
     'Kortix Team - Adam Cohen Hillel, Marko Kraemer, Domenico Gagliardi, and Quoc Dat Le',
   publisher:
     'Kortix Team - Adam Cohen Hillel, Marko Kraemer, Domenico Gagliardi, and Quoc Dat Le',
   category: 'Technology',
-  applicationName: 'Suna',
+  applicationName: 'MITOSIS',
   formatDetection: {
     telephone: false,
     email: false,
@@ -64,17 +64,17 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
-    title: 'Suna - Open Source Generalist AI Agent',
+    title: 'MITOSIS - Open Source Generalist AI Agent',
     description:
-      'Suna is a fully open source AI assistant that helps you accomplish real-world tasks with ease through natural conversation.',
+      'MITOSIS is a fully open source AI assistant that helps you accomplish real-world tasks with ease through natural conversation.',
     url: siteConfig.url,
-    siteName: 'Suna',
+    siteName: 'MITOSIS',
     images: [
       {
         url: '/banner.png',
         width: 1200,
         height: 630,
-        alt: 'Suna - Open Source Generalist AI Agent',
+        alt: 'MITOSIS - Open Source Generalist AI Agent',
         type: 'image/png',
       },
     ],
@@ -83,9 +83,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Suna - Open Source Generalist AI Agent',
+    title: 'MITOSIS - Open Source Generalist AI Agent',
     description:
-      'Suna is a fully open source AI assistant that helps you accomplish real-world tasks with ease through natural conversation.',
+      'MITOSIS is a fully open source AI assistant that helps you accomplish real-world tasks with ease through natural conversation.',
     creator: '@kortixai',
     site: '@kortixai',
     images: [
@@ -93,7 +93,7 @@ export const metadata: Metadata = {
         url: '/banner.png',
         width: 1200,
         height: 630,
-        alt: 'Suna - Open Source Generalist AI Agent',
+        alt: 'MITOSIS - Open Source Generalist AI Agent',
       },
     ],
   },

--- a/frontend/src/app/metadata.ts
+++ b/frontend/src/app/metadata.ts
@@ -4,7 +4,7 @@ import { siteConfig } from '@/lib/site';
 export const metadata: Metadata = {
   title: siteConfig.name,
   description: siteConfig.description,
-  keywords: ['Kortix Suna', 'AI', 'Agent'],
+  keywords: ['Kortix MITOSIS', 'AI', 'Agent'],
   authors: [
     {
       name: 'Kortix AI Corp',

--- a/frontend/src/components/home/sections/footer-section.tsx
+++ b/frontend/src/components/home/sections/footer-section.tsx
@@ -44,7 +44,7 @@ export function FooterSection() {
 
           <div className="flex items-center gap-4">
             <a
-              href="https://github.com/kortix-ai/suna"
+              href="https://github.com/kortix-ai/mitosis"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub"

--- a/frontend/src/components/home/sections/hero-section.tsx
+++ b/frontend/src/components/home/sections/hero-section.tsx
@@ -302,7 +302,7 @@ export function HeroSection() {
           </Link>
           <div className="flex flex-col items-center justify-center gap-5">
             <h1 className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-medium tracking-tighter text-balance text-center">
-              <span className="text-secondary">Suna</span>
+              <span className="text-secondary">MITOSIS</span>
               <span className="text-primary">, your AI Employee.</span>
             </h1>
             <p className="text-base md:text-lg text-center text-muted-foreground font-medium text-balance leading-relaxed tracking-tight">
@@ -368,7 +368,7 @@ export function HeroSection() {
               </button> */}
             </div>
             <DialogDescription className="text-muted-foreground">
-              Sign in or create an account to talk with Suna
+              Sign in or create an account to talk with MITOSIS
             </DialogDescription>
           </DialogHeader>
 

--- a/frontend/src/components/home/sections/navbar.tsx
+++ b/frontend/src/components/home/sections/navbar.tsx
@@ -214,7 +214,7 @@ export function Navbar() {
                       priority
                     />
                     <span className="font-medium text-primary text-sm">
-                      / Suna
+                      / MITOSIS
                     </span>
                   </Link>
                   <button

--- a/frontend/src/lib/site.ts
+++ b/frontend/src/lib/site.ts
@@ -1,6 +1,6 @@
 export const siteConfig = {
-  name: 'Kortix Suna',
-  url: 'https://suna.so/',
+  name: 'Kortix MITOSIS',
+  url: 'https://mitosis.so/',
   description: 'Kortix AI',
   links: {
     twitter: 'https://x.com/kortixai',


### PR DESCRIPTION
I replaced all visible instances of the old project name "SUNA" with the new name "MITOSIS" in your frontend application.

This includes changes in:
- Metadata (titles, descriptions, keywords, application name)
- Site configuration (site name, URL)
- Navigation elements (mobile drawer)
- Hero section content (main heading, dialog text)
- Footer links (GitHub repository URL)

The changes ensure that all user-visible text now reflects the new project branding. I assumed that URLs and repository names containing "suna" also change to "mitosis".