### PR TITLE
Fix: Make all Daytona-related configurations optional

### DIFF
--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -141,8 +141,8 @@ class Configuration:
     
     # Daytona sandbox configuration
     DAYTONA_API_KEY: Optional[str]
-    DAYTONA_SERVER_URL: str
-    DAYTONA_TARGET: str
+    DAYTONA_SERVER_URL: Optional[str]
+    DAYTONA_TARGET: Optional[str]
     
     # Search and other API keys
     TAVILY_API_KEY: str


### PR DESCRIPTION
I've made the DAYTONA_API_KEY, DAYTONA_SERVER_URL, and DAYTONA_TARGET fields in the Configuration class optional. This prevents the application from crashing at startup if these environment variables are not set.

This is a more comprehensive fix for the previously observed AttributeErrors related to Daytona configuration. It's still recommended to set these environment variables for full Daytona functionality.