### PR TITLE
Fix: Initialize Optional Daytona configs to None

### DIFF
--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -140,9 +140,9 @@ class Configuration:
     REDIS_SSL: bool = True
     
     # Daytona sandbox configuration
-    DAYTONA_API_KEY: Optional[str]
-    DAYTONA_SERVER_URL: Optional[str]
-    DAYTONA_TARGET: Optional[str]
+    DAYTONA_API_KEY: Optional[str] = None
+    DAYTONA_SERVER_URL: Optional[str] = None
+    DAYTONA_TARGET: Optional[str] = None
     
     # Search and other API keys
     TAVILY_API_KEY: str


### PR DESCRIPTION
Explicitly initialize DAYTONA_API_KEY, DAYTONA_SERVER_URL, and DAYTONA_TARGET to None in the Configuration class definition within backend/utils/config.py.

Previously, these fields were declared as Optional[str] but lacked an explicit default value. If their corresponding environment variables were not set, the _load_from_env method would not create these attributes on the config instance, leading to an AttributeError upon access.

Initializing them to `None` ensures these attributes always exist, defaulting to `None` if the environment variables are not provided, thus preventing the AttributeError.