### PR TITLE
Fix: Mount Docker socket into backend container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       - "8000:8000"
     volumes:
       - ./backend/.env:/app/.env:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     env_file:
       - ./backend/.env
     environment:


### PR DESCRIPTION
The backend service was unable to communicate with the Docker daemon because the Docker socket (`/var/run/docker.sock`) was not mounted into its container. This resulted in `FileNotFoundError` and errors stating that the "Local Docker client ... is not initialized" during sandbox creation.

This commit updates the `docker-compose.yaml` file to mount `/var/run/docker.sock` into the `backend` service. This allows the application running within the container to access the Docker API, which is necessary for its sandbox management functionality.

After applying this change, you should run:
`docker compose up --build -d`
to rebuild and restart the services. Subsequently, you should monitor the `mitosis-backend-1` logs to confirm the resolution of the Docker connectivity errors.