### PR TITLE
Input:

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     env_file:
       - ./backend/.env
+    user: root
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379


### PR DESCRIPTION
Diag: Run backend container as root for Docker socket permission testing

This commit modifies the `docker-compose.yaml` to run the `backend` service as the `root` user. This is a diagnostic step to determine if the `PermissionError(13, 'Permission denied')` encountered when accessing the mounted Docker socket (`/var/run/docker.sock`) is due to the `appuser` (UID 1000) not having sufficient privileges.

Running as root should bypass these permission checks. If this resolves the Docker client initialization error, it confirms the problem is related to user permissions on the socket.

This is intended for temporary diagnostics on development environments and is not recommended for production due to security implications.

Output:
Diag: Run backend container as root for Docker socket permission testing

I've modified the `docker-compose.yaml` to run the `backend` service as the `root` user. This is a diagnostic step to determine if the `PermissionError(13, 'Permission denied')` encountered when accessing the mounted Docker socket (`/var/run/docker.sock`) is due to the `appuser` (UID 1000) not having sufficient privileges.

Running as root should bypass these permission checks. If this resolves the Docker client initialization error, it confirms the problem is related to user permissions on the socket.

This is intended for temporary diagnostics on development environments and is not recommended for production due to security implications.