### PR TITLE
Fix: Correct arguments for get_or_start_sandbox calls

### DIFF
--- a/backend/sandbox/api.py
+++ b/backend/sandbox/api.py
@@ -126,12 +126,12 @@ async def get_sandbox_by_id_safely(client, sandbox_id: str):
         logger.error(f"No project found for sandbox ID: {sandbox_id}")
         raise HTTPException(status_code=404, detail="Sandbox not found - no project owns this sandbox ID")
     
-    # project_id = project_result.data[0]['project_id']
+    project_id = project_result.data[0]['project_id']
     # logger.debug(f"Found project {project_id} for sandbox {sandbox_id}")
     
     try:
         # Get the sandbox
-        sandbox = await get_or_start_sandbox(sandbox_id)
+        sandbox = await get_or_start_sandbox(project_id, client)
         # Extract just the sandbox object from the tuple (sandbox, sandbox_id, sandbox_pass)
         # sandbox = sandbox_tuple[0]
             
@@ -376,7 +376,7 @@ async def ensure_project_sandbox_active(
         
         # Get or start the sandbox
         logger.info(f"Ensuring sandbox is active for project {project_id}")
-        sandbox = await get_or_start_sandbox(sandbox_id)
+        sandbox = await get_or_start_sandbox(project_id, client)
         
         logger.info(f"Successfully ensured sandbox {sandbox_id} is active for project {project_id}")
         


### PR DESCRIPTION
The function `get_or_start_sandbox` expects `project_id` and `db_client` as arguments. Two call sites in `backend/sandbox/api.py` were invoking it incorrectly:
1. Missing the `db_client` argument.
2. Passing `sandbox_id` as `project_id` in one case, and not properly deriving/passing `project_id` in another.

This commit rectifies these calls in the `ensure_project_sandbox_active` and `get_sandbox_by_id_safely` functions within `backend/sandbox/api.py` to correctly pass both `project_id` and the `db_client` instance.

This resolves the TypeError:
`get_or_start_sandbox() missing 1 required positional argument: 'db_client'` and ensures the function receives the intended `project_id`.