### PR TITLE
Fix: Pass OpenRouter API key explicitly to LiteLLM

### DIFF
--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -154,6 +154,13 @@ def prepare_params(
             params["extra_headers"] = extra_headers
             logger.debug(f"Added OpenRouter site URL and app name to headers")
 
+        # Add OpenRouter API key
+        if config.OPENROUTER_API_KEY:
+            params["api_key"] = config.OPENROUTER_API_KEY
+            logger.debug("Added OpenRouter API key to params.")
+        else:
+            logger.warning("OpenRouter API key not found in config, API call may fail.")
+
     # Add Bedrock-specific parameters
     if model_name.startswith("bedrock/"):
         logger.debug(f"Preparing AWS Bedrock parameters for model: {model_name}")


### PR DESCRIPTION
The OpenRouter API calls were failing with an AuthenticationError (No auth credentials found) because the OPENROUTER_API_KEY, while loaded into the application's configuration, was not being explicitly passed to `litellm.acompletion`.

This commit modifies the `prepare_params` function in `backend/services/llm.py` to include the `api_key` in the parameters sent to LiteLLM when the model is an OpenRouter model. This ensures that LiteLLM receives the necessary credentials for authentication.

Added logging for when the key is successfully added or if it's missing from the configuration during an OpenRouter call.