### PR TITLE
Fix: Resolve 'deepseek' alias to Ollama by default

### DIFF
--- a/backend/utils/constants.py
+++ b/backend/utils/constants.py
@@ -117,7 +117,7 @@ MODEL_NAME_ALIASES = {
     # "gpt-4": "openai/gpt-4",  # Commented out in constants.py
     # "gemini-flash-2.5": "openrouter/google/gemini-2.5-flash-preview",  # Commented out in constants.py
     # "grok-3": "xai/grok-3-fast-latest",  # Commented out in constants.py
-    "deepseek": "openrouter/deepseek/deepseek-chat",
+    "deepseek": "ollama/deepseek",
     # "deepseek-r1": "openrouter/deepseek/deepseek-r1",
     # "grok-3-mini": "xai/grok-3-mini-fast-beta",  # Commented out in constants.py
     "qwen3": "openrouter/qwen/qwen3-235b-a22b",  # Commented out in constants.py


### PR DESCRIPTION
Previously, the model alias "deepseek" was hardcoded to resolve to "openrouter/deepseek/deepseek-chat". This caused issues when you intended to use a 'deepseek' model hosted via Ollama, leading to OpenRouter authentication errors if OpenRouter was not configured.

This commit changes the alias in `MODEL_NAME_ALIASES` (in `backend/utils/constants.py`) for "deepseek" to point to "ollama/deepseek". This ensures that requests for "deepseek" will now correctly use the Ollama provider and the configured `OLLAMA_API_BASE`.

This addresses your feedback indicating an intent to use Ollama for the 'deepseek' model.