### PR TITLE
Feat: Prefix Ollama model display names with 'Ollama:'

### DIFF
--- a/backend/services/billing.py
+++ b/backend/services/billing.py
@@ -933,7 +933,12 @@ async def get_available_models(
         # Create model info with display names for ALL models
         model_info = []
         for model in all_models:
-            display_name = model_aliases.get(model, model.split('/')[-1] if '/' in model else model)
+            if model.startswith("ollama/"):
+                actual_model_name = model.split('/')[-1]
+                display_name = f"Ollama:{actual_model_name}"
+            else:
+                # Use existing logic for other models (aliases or derived from ID)
+                display_name = model_aliases.get(model, model.split('/')[-1] if '/' in model else model)
             
             # Check if model requires subscription (not in free tier)
             requires_sub = model not in free_tier_models


### PR DESCRIPTION
I modified the `/api/billing/available-models` endpoint in `backend/services/billing.py` to change how display names are generated for Ollama models.

If a model ID starts with 'ollama/', its `display_name` in the API response will now be prefixed with 'Ollama:'. For example, a model with ID 'ollama/deepseek' will have 'Ollama:deepseek' as its display name.

This change allows the UI to directly show this prefix for Ollama models in dropdowns or selectors, as per your request, without needing frontend modifications for this specific formatting. Display names for other providers remain unaffected.