### PR TITLE
I've added some detailed type checking for `litellm.model_list`.

### DIFF
--- a/backend/services/billing.py
+++ b/backend/services/billing.py
@@ -883,6 +883,15 @@ async def get_available_models(
         logger.info(f"Checking OLLAMA_API_BASE. Value: '{config.OLLAMA_API_BASE}'")
         if config.OLLAMA_API_BASE:
             try:
+                logger.info(f"Type of litellm module: {type(litellm)}")
+                logger.info(f"Is litellm.model_list an attribute: {hasattr(litellm, 'model_list')}")
+                if hasattr(litellm, 'model_list'):
+                    logger.info(f"Type of litellm.model_list before call: {type(litellm.model_list)}")
+                    logger.info(f"Is litellm.model_list callable: {callable(litellm.model_list)}")
+                    # Optionally, to see a few attributes if it's a module/object:
+                    # logger.info(f"Some attributes of litellm.model_list: {dir(litellm.model_list)[:5] if hasattr(litellm.model_list, '__dict__') else 'N/A'}")
+                else:
+                    logger.warning("litellm module does not have 'model_list' attribute just before the call.")
                 logger.info(f"Attempting to fetch models from Ollama server at {config.OLLAMA_API_BASE} using asyncio.to_thread with litellm.model_list")
                 ollama_models_raw = await asyncio.to_thread(litellm.model_list, api_base=config.OLLAMA_API_BASE, provider="ollama")
                 if ollama_models_raw: # Assuming model_list returns a list (of dicts or ModelResponse objects)


### PR DESCRIPTION
I placed specific diagnostic log statements in the `get_available_models` function within `backend/services/billing.py`. These logs are situated right before the call to `asyncio.to_thread(litellm.model_list, ...)` and will output:
- The type of the imported `litellm` module.
- Whether `model_list` exists as an attribute on `litellm`.
- If it exists, the type of `litellm.model_list`.
- If it exists, whether `litellm.model_list` is callable.

This logging should help diagnose a `TypeError: 'list' object is not callable` that you're encountering when attempting to fetch models from an Ollama server.