### PR TITLE
Debug: Add module-level and enhanced local-scope logging for litellm.…

### DIFF
--- a/backend/services/billing.py
+++ b/backend/services/billing.py
@@ -16,6 +16,10 @@ from pydantic import BaseModel
 from utils.constants import MODEL_ACCESS_TIERS, MODEL_NAME_ALIASES
 import litellm # Added import for litellm
 import asyncio # Added import for asyncio
+
+# Module-level logging for litellm.model_list
+logger.info(f"BILLING.PY_MODULE_LOAD: Type of litellm.model_list: {type(litellm.model_list)}")
+logger.info(f"BILLING.PY_MODULE_LOAD: Is litellm.model_list callable: {callable(litellm.model_list)}")
 # Initialize Stripe
 stripe.api_key = config.STRIPE_SECRET_KEY
 
@@ -883,16 +887,16 @@ async def get_available_models(
         logger.info(f"Checking OLLAMA_API_BASE. Value: '{config.OLLAMA_API_BASE}'")
         if config.OLLAMA_API_BASE:
             try:
-                logger.info(f"Type of litellm module: {type(litellm)}")
-                logger.info(f"Is litellm.model_list an attribute: {hasattr(litellm, 'model_list')}")
+                logger.info(f"GET_AVAILABLE_MODELS: Type of litellm module: {type(litellm)}")
+                logger.info(f"GET_AVAILABLE_MODELS: Is litellm.model_list an attribute: {hasattr(litellm, 'model_list')}")
                 if hasattr(litellm, 'model_list'):
-                    logger.info(f"Type of litellm.model_list before call: {type(litellm.model_list)}")
-                    logger.info(f"Is litellm.model_list callable: {callable(litellm.model_list)}")
+                    logger.info(f"GET_AVAILABLE_MODELS: Type of litellm.model_list before call: {type(litellm.model_list)}")
+                    logger.info(f"GET_AVAILABLE_MODELS: Is litellm.model_list callable: {callable(litellm.model_list)}")
                     # Optionally, to see a few attributes if it's a module/object:
-                    # logger.info(f"Some attributes of litellm.model_list: {dir(litellm.model_list)[:5] if hasattr(litellm.model_list, '__dict__') else 'N/A'}")
+                    # logger.info(f"GET_AVAILABLE_MODELS: Some attributes of litellm.model_list: {dir(litellm.model_list)[:5] if hasattr(litellm.model_list, '__dict__') else 'N/A'}")
                 else:
-                    logger.warning("litellm module does not have 'model_list' attribute just before the call.")
-                logger.info(f"Attempting to fetch models from Ollama server at {config.OLLAMA_API_BASE} using asyncio.to_thread with litellm.model_list")
+                    logger.warning("GET_AVAILABLE_MODELS: litellm module does not have 'model_list' attribute.")
+                logger.info(f"GET_AVAILABLE_MODELS: Attempting to fetch models from Ollama server at {config.OLLAMA_API_BASE} using asyncio.to_thread with litellm.model_list")
                 ollama_models_raw = await asyncio.to_thread(litellm.model_list, api_base=config.OLLAMA_API_BASE, provider="ollama")
                 if ollama_models_raw: # Assuming model_list returns a list (of dicts or ModelResponse objects)
                     logger.info(f"Successfully fetched {len(ollama_models_raw)} model entries from Ollama.")


### PR DESCRIPTION
…model_list

To further diagnose the "TypeError: 'list' object is not callable" when attempting to use `litellm.model_list`, this commit adds more detailed logging in `backend/services/billing.py`:

1.  Module-level logs: Right after `import litellm`, logs are added to record the type and callability of `litellm.model_list` when the `billing.py` module is first imported. These logs are prefixed with `BILLING.PY_MODULE_LOAD:`.

2.  Enhanced local-scope logs: The existing diagnostic logs within the `get_available_models` function (just before the call to `asyncio.to_thread(litellm.model_list, ...)`) are now prefixed with `GET_AVAILABLE_MODELS:` for clear distinction from the module-level logs.

This will help determine if `litellm.model_list` is already a list upon module import or if it's being modified at a later stage.