### PR TITLE
I've made some changes to ensure Ollama models are correctly prefixed…

### DIFF
--- a/backend/agent/api.py
+++ b/backend/agent/api.py
@@ -363,7 +363,12 @@ async def start_agent(
     resolved_model = MODEL_NAME_ALIASES.get(model_name, model_name)
     logger.info(f"Resolved model name: {resolved_model}")
 
-    # Update model_name to use the resolved version
+    # Ensure Ollama models are correctly prefixed after alias resolution
+    if config.OLLAMA_API_BASE and '/' not in resolved_model:
+        resolved_model = f"ollama/{resolved_model}"
+        logger.info(f"Prefixed Ollama model name after alias resolution: {resolved_model}")
+
+    # Update model_name to use the (potentially prefixed) resolved version
     model_name = resolved_model
 
     logger.info(f"Starting new agent for thread: {thread_id} with config: model={model_name}, thinking={body.enable_thinking}, effort={body.reasoning_effort}, stream={body.stream}, context_manager={body.enable_context_manager} (Instance: {instance_id})")
@@ -896,7 +901,12 @@ async def initiate_agent_with_files(
     resolved_model = MODEL_NAME_ALIASES.get(model_name, model_name)
     logger.info(f"Resolved model name: {resolved_model}")
 
-    # Update model_name to use the resolved version
+    # Ensure Ollama models are correctly prefixed after alias resolution
+    if config.OLLAMA_API_BASE and '/' not in resolved_model:
+        resolved_model = f"ollama/{resolved_model}"
+        logger.info(f"Prefixed Ollama model name after alias resolution: {resolved_model}")
+
+    # Update model_name to use the (potentially prefixed) resolved version
     model_name = resolved_model
 
     logger.info(f"Starting new agent in agent builder mode: {is_agent_builder}, target_agent_id: {target_agent_id}")

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -95,6 +95,12 @@ def prepare_params(
     reasoning_effort: Optional[str] = 'low'
 ) -> Dict[str, Any]:
     """Prepare parameters for the API call."""
+
+    # Ensure Ollama models are correctly prefixed
+    if config.OLLAMA_API_BASE and '/' not in model_name:
+        model_name = f"ollama/{model_name}"
+        logger.info(f"Prefixed Ollama model name: {model_name}")
+
     params = {
         "model": model_name,
         "messages": messages,


### PR DESCRIPTION
… for LiteLLM.

Previously, the application was encountering an error (`litellm.BadRequestError: LLM Provider NOT provided`) when you used unprefixed Ollama model names like `gemma3:27b`. LiteLLM needs the provider prefix (for example, `ollama/gemma3:27b`).

Here's what I did:

1.  I adjusted the code in `backend/agent/api.py`:
    *   In the `/thread/{thread_id}/agent/start` and `/agent/initiate` sections, after handling model name aliases, I added a check. If `config.OLLAMA_API_BASE` is set and the model name doesn't have a prefix, I'll now add `ollama/` to the beginning of the model name.
    *   This makes sure the model name is in the correct format before it's used elsewhere.

2.  I also updated `backend/services/llm.py`:
    *   In the `prepare_params` function, I added similar logic as a fallback. If `config.OLLAMA_API_BASE` is set and the `model_name` parameter is unprefixed, I'll prepend `ollama/`. This provides an extra layer of safety.

These changes ensure that Ollama model names are correctly formatted before being sent to LiteLLM, which should resolve the error you were seeing.