### PR TITLE
Fix: Gracefully handle missing SMITHERY_API_KEY

### DIFF
--- a/backend/agent/tools/mcp_tool_wrapper.py
+++ b/backend/agent/tools/mcp_tool_wrapper.py
@@ -8,7 +8,7 @@ server tool calls through dynamically generated individual function methods.
 import json
 from typing import Any, Dict, List, Optional
 from agentpress.tool import Tool, ToolResult, openapi_schema, xml_schema, ToolSchema, SchemaType
-from mcp_local.client import MCPManager
+from mcp_local.client import MCPManager, SMITHERY_API_KEY
 from utils.logger import logger
 import inspect
 from mcp import ClientSession
@@ -51,9 +51,13 @@ class MCPToolWrapper(Tool):
             # Initialize standard MCP servers from Smithery
             standard_configs = [cfg for cfg in self.mcp_configs if not cfg.get('isCustom', False)]
             custom_configs = [cfg for cfg in self.mcp_configs if cfg.get('isCustom', False)]
-            
-            # Initialize standard MCPs through MCPManager
-            if standard_configs:
+
+            # Check for SMITHERY_API_KEY before processing standard_configs
+            if not SMITHERY_API_KEY:
+                logger.warning("SMITHERY_API_KEY is not set. Standard MCP servers (Smithery-based) will be unavailable.")
+                # Skip processing standard_configs if the API key is missing
+                pass # Effectively skips the next block if standard_configs was the only thing
+            elif standard_configs: # Only proceed if API key is present AND standard_configs exist
                 for config in standard_configs:
                     try:
                         await self.mcp_manager.connect_server(config)


### PR DESCRIPTION
Previously, if the SMITHERY_API_KEY environment variable was not set, I would still attempt to connect to each configured Smithery-based MCP server. This resulted in multiple connection error logs from the underlying MCP client library, as each connection attempt would fail due to the missing key. This could also contribute to instability in streaming operations if parts of the system expected these capabilities to be available.

This commit modifies my behavior to:
1. Check for the presence of `SMITHERY_API_KEY` before attempting to initialize standard (Smithery-based) MCP servers.
2. If the key is not set, log a clear warning message indicating that these servers will be unavailable.
3. Skip the connection attempts for standard MCPs if the key is missing, preventing the repeated errors.

Custom MCPs and other capabilities are unaffected and will initialize as before. This change ensures the application starts more cleanly and operates more predictably when the Smithery API key is not configured, preventing a cascade of errors and potential downstream issues.