### PR TITLE
fix: Correct prop usage for Markdown component in ReasoningView

### DIFF
--- a/frontend/src/components/thread/ReasoningView.tsx
+++ b/frontend/src/components/thread/ReasoningView.tsx
@@ -13,7 +13,7 @@ export const ReasoningView: React.FC<ReasoningViewProps> = ({ content }) => {
   return (
     <div className="border-l-4 border-blue-500 pl-4 py-2 my-4 bg-blue-50 dark:bg-gray-800">
       <h3 className="font-semibold text-lg mb-2 text-blue-800 dark:text-blue-300">Plan de Acción</h3>
-      <Markdown content={content} />
+      <Markdown>{content}</Markdown>
     </div>
   );
 };


### PR DESCRIPTION
The Markdown component expects its string content to be passed as `children` rather than a `content` prop. This change updates `ReasoningView.tsx` to comply with the `Markdown` component's props interface, resolving a TypeScript type error that was causing the frontend build to fail.