### PR TITLE
hotfix: Correct ContinueTaskTool import path in agent.run

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -20,7 +20,7 @@ from agent.tools.sb_files_tool import SandboxFilesTool
 from agent.tools.sb_browser_tool import SandboxBrowserTool
 from agent.tools.data_providers_tool import DataProvidersTool
 from agent.tools.expand_msg_tool import ExpandMessageTool
-from backend.agent.tools.continue_task_tool import ContinueTaskTool
+from agent.tools.continue_task_tool import ContinueTaskTool
 from agent.prompt import get_system_prompt
 from utils.logger import logger
 from utils.auth_utils import get_account_id_from_thread


### PR DESCRIPTION
I changed the import for `ContinueTaskTool` in `backend/agent/run.py` from `backend.agent.tools.continue_task_tool` to `agent.tools.continue_task_tool`.

The previous path caused a `ModuleNotFoundError` because the application's working directory (`/app`) already serves as the root for these imports. Removing the `backend.` prefix resolves the startup error in the backend service.