### PR TITLE
fix: Correct base Tool initialization in ContinueTaskTool

### DIFF
--- a/backend/agent/tools/continue_task_tool.py
+++ b/backend/agent/tools/continue_task_tool.py
@@ -9,7 +9,15 @@ Only call this tool after you have successfully completed a step and are ready f
 
 class ContinueTaskTool(Tool):
     def __init__(self):
-        super().__init__(TOOL_NAME, TOOL_DESCRIPTION)
+        super().__init__() # Llamar al constructor de la clase base sin argumentos
+        # TOOL_NAME y TOOL_DESCRIPTION pueden permanecer como constantes a nivel de módulo
+        # o asignarse a self.name y self.description si fueran necesarios en otro lugar,
+        # pero para resolver el TypeError, solo se necesita corregir la llamada a super.
+        # Por simplicidad y dado que esta herramienta es especial, mantenerlos como constantes
+        # del módulo está bien por ahora. Si se necesitara que la herramienta se muestre
+        # en una UI de configuración, se podrían asignar aquí:
+        # self.name = TOOL_NAME
+        # self.description = TOOL_DESCRIPTION
 
     def run(self, **kwargs) -> str:
         # This tool doesn't need to return anything meaningful.


### PR DESCRIPTION
I've modified `ContinueTaskTool` to call `super().__init__()` without arguments, aligning with the base `Tool` class constructor defined in `backend/agentpress/tool.py`.

This resolves the `TypeError: Tool.__init__() takes 1 positional argument but 3 were given` that occurred during the registration of `ContinueTaskTool`.

Additionally, I reviewed `MessageTool` and `SandboxToolsBase` and confirmed they correctly initialize the base `Tool` class.