### PR TITLE
Fix: Ensure `ContinueTaskTool` is correctly registered and exposed

### DIFF
--- a/backend/agent/tools/continue_task_tool.py
+++ b/backend/agent/tools/continue_task_tool.py
@@ -1,25 +1,23 @@
-from agentpress.tool import Tool
+# backend/agent/tools/continue_task_tool.py
+from agentpress.tool import Tool # Verificar que esta ruta de importación sea la correcta para la clase base Tool
 
 TOOL_NAME = "continue_task"
-TOOL_DESCRIPTION = """
-Use this tool when you have completed a step in your plan and there are more steps to follow.
-This will allow you to continue working on the next step of your plan without user intervention.
-Only call this tool after you have successfully completed a step and are ready for the next one.
-"""
+TOOL_DESCRIPTION = """Use this tool when you have completed a step in your plan and there are more steps to follow. This will allow you to continue working on the next step of your plan without user intervention. Only call this tool after you have successfully completed a step and are ready for the next one."""
 
 class ContinueTaskTool(Tool):
-    def __init__(self):
-        super().__init__() # Llamar al constructor de la clase base sin argumentos
-        # TOOL_NAME y TOOL_DESCRIPTION pueden permanecer como constantes a nivel de módulo
-        # o asignarse a self.name y self.description si fueran necesarios en otro lugar,
-        # pero para resolver el TypeError, solo se necesita corregir la llamada a super.
-        # Por simplicidad y dado que esta herramienta es especial, mantenerlos como constantes
-        # del módulo está bien por ahora. Si se necesitara que la herramienta se muestre
-        # en una UI de configuración, se podrían asignar aquí:
-        # self.name = TOOL_NAME
-        # self.description = TOOL_DESCRIPTION
+    # Estos atributos de clase son importantes para que ToolRegistry identifique la herramienta.
+    name = TOOL_NAME
+    description = TOOL_DESCRIPTION
 
-    def run(self, **kwargs) -> str:
-        # This tool doesn't need to return anything meaningful.
-        # Its purpose is to signal the execution loop.
-        return "Continuing to the next step."
+    def __init__(self):
+        super().__init__() # Llamada al constructor base sin argumentos.
+
+    # Modificar la firma del método 'run' para que no acepte **kwargs.
+    # Debe ser un método simple sin argumentos (aparte de 'self') para que
+    # el sistema de introspección de la clase base 'Tool' pueda generar su esquema correctamente.
+    def run(self) -> str:
+        """
+        Signals the agent to continue with the next step in its plan.
+        This tool is invoked without arguments from the LLM.
+        """
+        return "ContinueTaskTool executed: Signalling agent to proceed."


### PR DESCRIPTION
This commit addresses an issue where `ContinueTaskTool` might not be correctly registered or its `run` method properly exposed for schema introspection.

Changes made:
- Modified `backend/agent/tools/continue_task_tool.py`:
    - Added the required class attributes `name = TOOL_NAME` and `description = TOOL_DESCRIPTION`.
    - Changed the `run` method signature from `run(self, **kwargs)` to `run(self) -> str`.
    - Updated the `run` method to return the specific string: "ContinueTaskTool executed: Signalling agent to proceed."
- Verified that `backend/agent/run.py` correctly imports and registers `ContinueTaskTool`. No changes were required in this file as the existing registration mechanism is appropriate.

These changes ensure that `ContinueTaskTool` adheres to the expected structure, allowing it to be correctly identified and its schema generated.