### PR TITLE
Fix: Add git to Dockerfile dependencies

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,10 +9,7 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends     build-essential     curl     git     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and set up directories
 RUN useradd -m -u 1000 appuser && \


### PR DESCRIPTION
The Docker build process was failing because 'git' was not found. This was caused by pip attempting to install a dependency from a git+https URL specified in requirements.txt (the suna package itself).

This commit adds 'git' to the list of packages installed via apt-get in the backend/Dockerfile, allowing pip to correctly handle git-based dependencies during the Docker image build.