### PR TITLE
Fix: Remove git+https dependency for suna package from requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -102,7 +102,6 @@ starlette==0.36.3
 storage3==0.11.3
 StrEnum==0.4.15
 stripe==12.0.1
--e git+https://github.com/Arx88/Mitosis@8cf7449ed2f70080c35a3a3a79f84f1effec6614#egg=suna&subdirectory=backend
 supabase==2.15.0
 supafunc==0.9.4
 tavily-python==0.5.4


### PR DESCRIPTION
The requirements.txt file contained a line attempting to install the suna package (the backend application itself) from a specific git commit: git+https://github.com/Arx88/Mitosis@...#egg=suna&subdirectory=backend

This was causing errors during Docker build because:
1. The specific commit hash was not found on the remote ("not our ref").
2. Installing the application code this way is redundant, as the Dockerfile already copies the application source code into the image.

This commit removes the problematic line from backend/requirements.txt. The application will use the code copied via the Dockerfile's COPY command.