### PR TITLE
Fix: Add fallback for Ollama project naming if model unavailable

### DIFF
--- a/backend/utils/constants.py
+++ b/backend/utils/constants.py
@@ -143,3 +143,5 @@ MODEL_NAME_ALIASES = {
     # "qwen/qwen3-235b-a22b": "openrouter/qwen/qwen3-235b-a22b",
     # "xai/grok-3-mini-fast-beta": "xai/grok-3-mini-fast-beta",  # Commented out in constants.py
 }
+
+MODEL_TO_USE_FALLBACK_FOR_NAMING = "openrouter/google/gemini-2.5-flash-preview-05-20"


### PR DESCRIPTION
Implements a fallback mechanism for project name generation when the configured MODEL_TO_USE is an Ollama model that is not available.

Changes:
- Added `MODEL_TO_USE_FALLBACK_FOR_NAMING` constant in `backend/utils/constants.py`.
- Introduced `is_ollama_model_available` helper in `backend/services/llm.py` to check if a given Ollama model (unprefixed) is present in the Ollama instance by querying its `/api/tags` endpoint.
- Modified `generate_and_update_project_name` in `backend/agent/api.py`:
  - If the configured model for naming is an Ollama model, it now calls `is_ollama_model_available`.
  - If the model is not found, a warning is logged, and the system falls back to using `MODEL_TO_USE_FALLBACK_FOR_NAMING`.
  - This makes the project naming more resilient to misconfigurations or missing Ollama models.
- Fixed a "No newline at end of file" issue in `backend/utils/constants.py`.