### PR TITLE
Fix: Correct response unpacking in SandboxBrowserTool

### DIFF
--- a/backend/agent/tools/sb_browser_tool.py
+++ b/backend/agent/tools/sb_browser_tool.py
@@ -50,23 +50,13 @@ class SandboxBrowserTool(SandboxToolsBase):
             # as per the implied change in the subtask description.
             raw_response = self.sandbox.process.execute(curl_cmd, timeout=30)
             
-            exit_code = raw_response[0]
-            stdout_bytes = raw_response[1][0] if raw_response[1] else b""
-            stderr_bytes = raw_response[1][1] if raw_response[1] else b""
+            exit_code = raw_response.exit_code
+            stdout_str = raw_response.result if raw_response.result is not None else ""
+            stderr_str = raw_response.stderr if raw_response.stderr is not None else ""
 
-            if isinstance(stdout_bytes, bytes):
-                stdout_str = stdout_bytes.decode('utf-8', errors='replace')
-            elif isinstance(stdout_bytes, str):
-                stdout_str = stdout_bytes
-            else:
-                stdout_str = ""
-
-            if isinstance(stderr_bytes, bytes):
-                stderr_str = stderr_bytes.decode('utf-8', errors='replace')
-            elif isinstance(stderr_bytes, str):
-                stderr_str = stderr_bytes
-            else:
-                stderr_str = ""
+            logger.debug(f"SandboxBrowserTool: exit_code: {exit_code}")
+            logger.debug(f"SandboxBrowserTool: stdout_str before JSON parsing: '{stdout_str}'")
+            logger.debug(f"SandboxBrowserTool: stderr_str: '{stderr_str}'")
 
             if exit_code == 0:
                 try:


### PR DESCRIPTION
This commit resolves a persistent AttributeError and JSON parsing error in `SandboxBrowserTool._execute_browser_action`.

The primary issue was that `_execute_browser_action` incorrectly unpacked the response from `self.sandbox.process.execute()`. The method was expecting a tuple like `(exit_code, (stdout_bytes, stderr_bytes))` but `LocalDockerProcessWrapper.execute` (as confirmed by reviewing `sandbox.py`) returns an `ExecResponse` namedtuple: `(exit_code, result, stderr)`, where `result` is already a decoded stdout string and `stderr` is a decoded stderr string.

Changes made:
- Modified `_execute_browser_action` in `sb_browser_tool.py` to correctly access response elements using attribute access:
    - `raw_response.exit_code`
    - `raw_response.result` (for stdout_str)
    - `raw_response.stderr` (for stderr_str)
- Removed the now-redundant type-checking logic that attempted to decode bytes, as the `result` and `stderr` attributes are already strings. Simplified assignment to `stdout_str` and `stderr_str`, handling potential `None` values by defaulting to empty strings.
- Added debug logging before attempting to parse JSON:
    - Logs `exit_code`, `stdout_str` (before parsing), and `stderr_str`. This will help diagnose if `curl` returns non-JSON output.
- Verified that the `json.JSONDecodeError` exception handler correctly logs the `stdout_str` that caused the parsing failure.

The issue regarding my file creation capabilities was previously investigated, and no changes were needed as the problematic code was not present.