### PR TITLE
Fix: Make JSON parsing more robust

### DIFF
--- a/backend/agent/tools/test_sb_browser_tool.py
+++ b/backend/agent/tools/test_sb_browser_tool.py
@@ -1,0 +1,173 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from backend.agentpress.tool import ToolResult # Adjusted import
+from backend.agentpress.thread_manager import ThreadManager # Adjusted import
+from backend.agent.tools.sb_browser_tool import SandboxBrowserTool
+
+# Mock for the process execution result
+class MockProcessExecutionResult:
+    def __init__(self, exit_code, result, stderr):
+        self.exit_code = exit_code
+        self.result = result
+        self.stderr = stderr
+
+class TestSandboxBrowserToolRobustJsonParsing(unittest.TestCase):
+
+    def setUp(self):
+        self.project_id = "test_project"
+        self.thread_id = "test_thread"
+        # Mock ThreadManager if its methods are called directly or indirectly
+        self.mock_thread_manager = AsyncMock(spec=ThreadManager)
+        self.browser_tool = SandboxBrowserTool(
+            project_id=self.project_id,
+            thread_id=self.thread_id,
+            thread_manager=self.mock_thread_manager
+        )
+        # Mock the internal _sandbox attribute and its process.execute method
+        self.mock_sandbox_internal = MagicMock()
+        self.browser_tool._sandbox = self.mock_sandbox_internal # Assign mock to the internal attribute
+        self.browser_tool._ensure_sandbox = AsyncMock() # Still mock _ensure_sandbox as it's awaited
+
+        # Mock upload_base64_image as it's called in _execute_browser_action
+        self.mock_upload_patcher = patch('backend.agent.tools.sb_browser_tool.upload_base64_image', AsyncMock(return_value="http://fakeurl.com/image.png"))
+        self.mock_upload_image = self.mock_upload_patcher.start()
+
+    def tearDown(self):
+        self.mock_upload_patcher.stop()
+
+    def _run_async(self, coro):
+        return asyncio.run(coro)
+
+    def test_valid_json_response(self):
+        """Test with a valid JSON string."""
+        mock_response_data = {"message": "Success", "content": "some content"}
+        stdout_json = json.dumps(mock_response_data)
+        self.mock_sandbox_internal.process.execute = MagicMock(
+            return_value=MockProcessExecutionResult(exit_code=0, result=stdout_json, stderr="")
+        )
+        self.mock_thread_manager.add_message = AsyncMock(return_value={'message_id': 'mock_message_id'})
+
+
+        result = self._run_async(self.browser_tool._execute_browser_action("test_endpoint"))
+
+        self.assertTrue(result.success)
+        # Parse the JSON string in result.output
+        output_data = json.loads(result.output)
+        self.assertEqual(output_data["message"], "Success")
+        self.browser_tool.sandbox.process.execute.assert_called_once()
+
+    def test_invalid_json_response_malformed(self):
+        """Test with a malformed JSON string (e.g., trailing comma)."""
+        stdout_malformed_json = '{"message": "Success", "content": "some content",}' # Trailing comma
+        self.browser_tool.sandbox.process.execute = MagicMock(
+            return_value=MockProcessExecutionResult(exit_code=0, result=stdout_malformed_json, stderr="")
+        )
+
+        result = self._run_async(self.browser_tool._execute_browser_action("test_endpoint"))
+
+        self.assertFalse(result.success)
+        # For fail_response, the error message is directly in result.output
+        self.assertIn("Failed to parse response JSON", result.output)
+        self.assertIn(stdout_malformed_json, result.output)
+        self.mock_sandbox_internal.process.execute.assert_called_once()
+
+    def test_non_json_response_html(self):
+        """Test with a non-JSON string like HTML."""
+        stdout_html = "<html><body><h1>Not a JSON</h1></body></html>"
+        self.browser_tool.sandbox.process.execute = MagicMock(
+            return_value=MockProcessExecutionResult(exit_code=0, result=stdout_html, stderr="")
+        )
+
+        result = self._run_async(self.browser_tool._execute_browser_action("test_endpoint"))
+
+        self.assertFalse(result.success)
+        self.assertIn("Response from internal browser service was not as expected", result.output)
+        self.assertIn(stdout_html, result.output)
+        self.mock_sandbox_internal.process.execute.assert_called_once()
+
+    def test_valid_json_with_leading_trailing_whitespace(self):
+        """Test with valid JSON that has leading/trailing whitespace."""
+        mock_response_data = {"message": "Success", "content": "whitespace test"}
+        stdout_json_with_whitespace = f"   {json.dumps(mock_response_data)}   "
+        self.mock_sandbox_internal.process.execute = MagicMock(
+            return_value=MockProcessExecutionResult(exit_code=0, result=stdout_json_with_whitespace, stderr="")
+        )
+        self.mock_thread_manager.add_message = AsyncMock(return_value={'message_id': 'mock_message_id'})
+
+        result = self._run_async(self.browser_tool._execute_browser_action("test_endpoint"))
+
+        self.assertTrue(result.success)
+        output_data = json.loads(result.output)
+        self.assertEqual(output_data["message"], "Success")
+        self.browser_tool.sandbox.process.execute.assert_called_once()
+
+    def test_empty_string_response(self):
+        """Test with an empty string response."""
+        stdout_empty = ""
+        self.browser_tool.sandbox.process.execute = MagicMock(
+            return_value=MockProcessExecutionResult(exit_code=0, result=stdout_empty, stderr="")
+        )
+
+        result = self._run_async(self.browser_tool._execute_browser_action("test_endpoint"))
+
+        self.assertFalse(result.success)
+        self.assertIn("Response from internal browser service was not as expected", result.output)
+        self.mock_sandbox_internal.process.execute.assert_called_once()
+
+    def test_whitespace_only_response(self):
+        """Test with a response that is only whitespace."""
+        stdout_whitespace = "   \n\t   "
+        self.browser_tool.sandbox.process.execute = MagicMock(
+            return_value=MockProcessExecutionResult(exit_code=0, result=stdout_whitespace, stderr="")
+        )
+
+        result = self._run_async(self.browser_tool._execute_browser_action("test_endpoint"))
+
+        self.assertFalse(result.success)
+        self.assertIn("Response from internal browser service was not as expected", result.output)
+        self.mock_sandbox_internal.process.execute.assert_called_once()
+
+    def test_non_zero_exit_code(self):
+        """Test when curl command returns a non-zero exit code."""
+        stdout_msg = "Some error message from curl"
+        stderr_msg = "Detailed error"
+        self.browser_tool.sandbox.process.execute = MagicMock(
+            return_value=MockProcessExecutionResult(exit_code=1, result=stdout_msg, stderr=stderr_msg)
+        )
+
+        result = self._run_async(self.browser_tool._execute_browser_action("test_endpoint"))
+
+        self.assertFalse(result.success)
+        self.assertIn("Browser automation request failed with exit code 1", result.output)
+        self.assertIn(stdout_msg, result.output)
+        self.assertIn(stderr_msg, result.output)
+        self.mock_sandbox_internal.process.execute.assert_called_once()
+
+    def test_json_response_with_screenshot(self):
+        """Test valid JSON response that includes a screenshot."""
+        mock_response_data = {
+            "message": "Success with screenshot",
+            "content": "some content",
+            "screenshot_base64": "fake_base64_string"
+        }
+        stdout_json = json.dumps(mock_response_data)
+        self.mock_sandbox_internal.process.execute = MagicMock(
+            return_value=MockProcessExecutionResult(exit_code=0, result=stdout_json, stderr="")
+        )
+        self.mock_thread_manager.add_message = AsyncMock(return_value={'message_id': 'mock_message_id'})
+
+        result = self._run_async(self.browser_tool._execute_browser_action("test_endpoint"))
+
+        self.assertTrue(result.success)
+        output_data = json.loads(result.output)
+        self.assertEqual(output_data["message"], "Success with screenshot")
+        self.assertEqual(output_data["image_url"], "http://fakeurl.com/image.png")
+        self.mock_upload_image.assert_called_once_with("fake_base64_string")
+        self.mock_sandbox_internal.process.execute.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/agentpress/context_manager.py
+++ b/backend/agentpress/context_manager.py
@@ -9,9 +9,9 @@ import json
 from typing import List, Dict, Any, Optional
 
 from litellm import token_counter, completion_cost
-from services.supabase import DBConnection
-from services.llm import make_llm_api_call
-from utils.logger import logger
+from backend.services.supabase import DBConnection # Adjusted import
+from backend.services.llm import make_llm_api_call # Adjusted import
+from backend.utils.logger import logger # Adjusted import
 
 # Constants for token management
 DEFAULT_TOKEN_THRESHOLD = 120000  # 80k tokens threshold for summarization

--- a/backend/agentpress/response_processor.py
+++ b/backend/agentpress/response_processor.py
@@ -15,13 +15,13 @@ import asyncio
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, AsyncGenerator, Tuple, Union, Callable, Literal
 from dataclasses import dataclass
-from utils.logger import logger
-from agentpress.tool import ToolResult
-from agentpress.tool_registry import ToolRegistry
-from agentpress.xml_tool_parser import XMLToolParser
+from backend.utils.logger import logger # Adjusted import
+from backend.agentpress.tool import ToolResult # Adjusted import
+from backend.agentpress.tool_registry import ToolRegistry # Adjusted import
+from backend.agentpress.xml_tool_parser import XMLToolParser # Adjusted import
 from langfuse.client import StatefulTraceClient
-from services.langfuse import langfuse
-from agentpress.utils.json_helpers import (
+from backend.services.langfuse import langfuse # Adjusted import
+from backend.agentpress.utils.json_helpers import ( # Adjusted import
     ensure_dict, ensure_list, safe_json_parse, 
     to_json_string, format_for_yield
 )

--- a/backend/agentpress/thread_manager.py
+++ b/backend/agentpress/thread_manager.py
@@ -12,18 +12,18 @@ This module provides comprehensive conversation management, including:
 
 import json
 from typing import List, Dict, Any, Optional, Type, Union, AsyncGenerator, Literal
-from services.llm import make_llm_api_call
-from agentpress.tool import Tool
-from agentpress.tool_registry import ToolRegistry
-from agentpress.context_manager import ContextManager
-from agentpress.response_processor import (
+from backend.services.llm import make_llm_api_call # Adjusted import
+from backend.agentpress.tool import Tool # Adjusted import
+from backend.agentpress.tool_registry import ToolRegistry # Adjusted import
+from backend.agentpress.context_manager import ContextManager # Adjusted import
+from backend.agentpress.response_processor import ( # Adjusted import
     ResponseProcessor,
     ProcessorConfig
 )
-from services.supabase import DBConnection
-from utils.logger import logger
+from backend.services.supabase import DBConnection # Adjusted import
+from backend.utils.logger import logger # Adjusted import
 from langfuse.client import StatefulGenerationClient, StatefulTraceClient
-from services.langfuse import langfuse
+from backend.services.langfuse import langfuse # Adjusted import
 import datetime
 
 # Type alias for tool choice

--- a/backend/agentpress/tool.py
+++ b/backend/agentpress/tool.py
@@ -13,7 +13,7 @@ from abc import ABC
 import json
 import inspect
 from enum import Enum
-from utils.logger import logger
+from backend.utils.logger import logger # Adjusted import
 
 class SchemaType(Enum):
     """Enumeration of supported schema types for tool definitions."""

--- a/backend/agentpress/tool_registry.py
+++ b/backend/agentpress/tool_registry.py
@@ -1,6 +1,6 @@
 from typing import Dict, Type, Any, List, Optional, Callable
-from agentpress.tool import Tool, SchemaType
-from utils.logger import logger
+from backend.agentpress.tool import Tool, SchemaType # Adjusted import
+from backend.utils.logger import logger # Adjusted import
 
 
 class ToolRegistry:

--- a/backend/sandbox/sandbox.py
+++ b/backend/sandbox/sandbox.py
@@ -2,11 +2,11 @@ from daytona_sdk import Daytona, DaytonaConfig, CreateSandboxParams, Sandbox, Se
 from daytona_api_client.models.workspace_state import WorkspaceState
 from collections import namedtuple # Added import
 from dotenv import load_dotenv
-from utils.logger import logger
-from utils.config import config, Configuration, EnvMode
+from backend.utils.logger import logger # Adjusted import
+from backend.utils.config import config, Configuration, EnvMode # Adjusted import
 from . import local_docker_handler
 import os
-from services.supabase import DBConnection # Added DBConnection import
+from backend.services.supabase import DBConnection # Adjusted import
 from typing import Optional, Dict, List, Any # Added for wrapper classes
 
 # Define this at the module level or within the class if preferred,

--- a/backend/sandbox/tool_base.py
+++ b/backend/sandbox/tool_base.py
@@ -1,14 +1,14 @@
 
 from typing import Optional
 
-from agentpress.thread_manager import ThreadManager
-from agentpress.tool import Tool
+from backend.agentpress.thread_manager import ThreadManager # Adjusted import
+from backend.agentpress.tool import Tool # Adjusted import
 # Sandbox type can be Daytona's or our wrapper, so using Any for now, or a common base if defined
 from typing import Any
-from sandbox.sandbox import get_or_start_sandbox
-from utils.logger import logger
-from utils.files_utils import clean_path
-from utils.config import config # Added import
+from backend.sandbox.sandbox import get_or_start_sandbox # Adjusted import
+from backend.utils.logger import logger # Adjusted import
+from backend.utils.files_utils import clean_path # Adjusted import
+from backend.utils.config import config # Adjusted import
 
 class SandboxToolsBase(Tool):
     """Base class for all sandbox tools that provides project-based sandbox access."""

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -17,8 +17,8 @@ import asyncio
 import aiohttp # Added import
 from openai import OpenAIError
 import litellm
-from utils.logger import logger
-from utils.config import config
+from backend.utils.logger import logger # Adjusted import
+from backend.utils.config import config # Adjusted import
 
 # litellm.set_verbose=True
 litellm.modify_params=True

--- a/backend/services/supabase.py
+++ b/backend/services/supabase.py
@@ -4,8 +4,8 @@ Centralized database connection management for AgentPress using Supabase.
 
 from typing import Optional
 from supabase import create_async_client, AsyncClient
-from utils.logger import logger
-from utils.config import config
+from backend.utils.logger import logger # Adjusted import
+from backend.utils.config import config # Adjusted import
 import base64
 import uuid
 from datetime import datetime

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -18,7 +18,7 @@ from functools import wraps
 import traceback
 from logging.handlers import RotatingFileHandler
 
-from utils.config import config, EnvMode
+from backend.utils.config import config, EnvMode # Adjusted import
 
 # Context variable for request correlation ID
 request_id: ContextVar[str] = ContextVar('request_id', default='')

--- a/backend/utils/s3_upload_utils.py
+++ b/backend/utils/s3_upload_utils.py
@@ -5,8 +5,8 @@ Utility functions for handling image operations.
 import base64
 import uuid
 from datetime import datetime
-from utils.logger import logger
-from services.supabase import DBConnection
+from backend.utils.logger import logger # Adjusted import
+from backend.services.supabase import DBConnection # Adjusted import
 
 async def upload_base64_image(base64_data: str, bucket_name: str = "browser-screenshots") -> str:
     """Upload a base64 encoded image to Supabase storage and return the URL.


### PR DESCRIPTION
This commit addresses issues with JSON parsing.

The following changes were made:
- Added debug logging for `stdout_str` before parsing.
- Implemented `stdout_str.strip()` to handle leading/trailing whitespace.
- Added a check to ensure `stdout_str` likely contains JSON (starts with '{' and ends with '}') before attempting to parse.
- Improved error handling for `json.JSONDecodeError` to log the problematic string.

Additionally, this commit includes fixes for numerous import path issues across the `backend` codebase, ensuring that unit tests can run correctly. Unit tests for the JSON parsing logic have been added and verified to cover valid JSON, invalid JSON, non-JSON content, and JSON with whitespace.