### PR TITLE
Fix: Resolve ModuleNotFoundError by using relative imports

### DIFF
--- a/backend/agent/tools/sb_browser_tool.py
+++ b/backend/agent/tools/sb_browser_tool.py
@@ -1,11 +1,11 @@
 import traceback
 import json
 
-from backend.agentpress.tool import ToolResult, openapi_schema, xml_schema # Adjusted import
-from backend.agentpress.thread_manager import ThreadManager # Adjusted import
-from backend.sandbox.tool_base import SandboxToolsBase # Adjusted import
-from backend.utils.logger import logger # Adjusted import
-from backend.utils.s3_upload_utils import upload_base64_image # Adjusted import
+from ...agentpress.tool import ToolResult, openapi_schema, xml_schema # Relative import
+from ...agentpress.thread_manager import ThreadManager # Relative import
+from ...sandbox.tool_base import SandboxToolsBase # Relative import
+from ...utils.logger import logger # Relative import
+from ...utils.s3_upload_utils import upload_base64_image # Relative import
 
 
 class SandboxBrowserTool(SandboxToolsBase):

--- a/backend/agentpress/context_manager.py
+++ b/backend/agentpress/context_manager.py
@@ -9,9 +9,9 @@ import json
 from typing import List, Dict, Any, Optional
 
 from litellm import token_counter, completion_cost
-from backend.services.supabase import DBConnection # Adjusted import
-from backend.services.llm import make_llm_api_call # Adjusted import
-from backend.utils.logger import logger # Adjusted import
+from ..services.supabase import DBConnection # Relative import
+from ..services.llm import make_llm_api_call # Relative import
+from ..utils.logger import logger # Relative import
 
 # Constants for token management
 DEFAULT_TOKEN_THRESHOLD = 120000  # 80k tokens threshold for summarization

--- a/backend/agentpress/response_processor.py
+++ b/backend/agentpress/response_processor.py
@@ -15,13 +15,13 @@ import asyncio
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, AsyncGenerator, Tuple, Union, Callable, Literal
 from dataclasses import dataclass
-from backend.utils.logger import logger # Adjusted import
-from backend.agentpress.tool import ToolResult # Adjusted import
-from backend.agentpress.tool_registry import ToolRegistry # Adjusted import
-from backend.agentpress.xml_tool_parser import XMLToolParser # Adjusted import
+from ..utils.logger import logger # Relative import
+from .tool import ToolResult # Relative import
+from .tool_registry import ToolRegistry # Relative import
+from .xml_tool_parser import XMLToolParser # Relative import
 from langfuse.client import StatefulTraceClient
-from backend.services.langfuse import langfuse # Adjusted import
-from backend.agentpress.utils.json_helpers import ( # Adjusted import
+from ..services.langfuse import langfuse # Relative import
+from .utils.json_helpers import ( # Relative import
     ensure_dict, ensure_list, safe_json_parse, 
     to_json_string, format_for_yield
 )

--- a/backend/agentpress/thread_manager.py
+++ b/backend/agentpress/thread_manager.py
@@ -12,18 +12,18 @@ This module provides comprehensive conversation management, including:
 
 import json
 from typing import List, Dict, Any, Optional, Type, Union, AsyncGenerator, Literal
-from backend.services.llm import make_llm_api_call # Adjusted import
-from backend.agentpress.tool import Tool # Adjusted import
-from backend.agentpress.tool_registry import ToolRegistry # Adjusted import
-from backend.agentpress.context_manager import ContextManager # Adjusted import
-from backend.agentpress.response_processor import ( # Adjusted import
+from ..services.llm import make_llm_api_call
+from .tool import Tool
+from .tool_registry import ToolRegistry
+from .context_manager import ContextManager
+from .response_processor import (
     ResponseProcessor,
     ProcessorConfig
 )
-from backend.services.supabase import DBConnection # Adjusted import
-from backend.utils.logger import logger # Adjusted import
+from ..services.supabase import DBConnection
+from ..utils.logger import logger
 from langfuse.client import StatefulGenerationClient, StatefulTraceClient
-from backend.services.langfuse import langfuse # Adjusted import
+from ..services.langfuse import langfuse
 import datetime
 
 # Type alias for tool choice

--- a/backend/agentpress/tool.py
+++ b/backend/agentpress/tool.py
@@ -13,7 +13,7 @@ from abc import ABC
 import json
 import inspect
 from enum import Enum
-from backend.utils.logger import logger # Adjusted import
+from ..utils.logger import logger # Relative import
 
 class SchemaType(Enum):
     """Enumeration of supported schema types for tool definitions."""

--- a/backend/agentpress/tool_registry.py
+++ b/backend/agentpress/tool_registry.py
@@ -1,6 +1,6 @@
 from typing import Dict, Type, Any, List, Optional, Callable
-from backend.agentpress.tool import Tool, SchemaType # Adjusted import
-from backend.utils.logger import logger # Adjusted import
+from .tool import Tool, SchemaType # Relative import
+from ..utils.logger import logger # Relative import
 
 
 class ToolRegistry:

--- a/backend/sandbox/sandbox.py
+++ b/backend/sandbox/sandbox.py
@@ -2,11 +2,11 @@ from daytona_sdk import Daytona, DaytonaConfig, CreateSandboxParams, Sandbox, Se
 from daytona_api_client.models.workspace_state import WorkspaceState
 from collections import namedtuple # Added import
 from dotenv import load_dotenv
-from backend.utils.logger import logger # Adjusted import
-from backend.utils.config import config, Configuration, EnvMode # Adjusted import
+from ..utils.logger import logger # Relative import
+from ..utils.config import config, Configuration, EnvMode # Relative import
 from . import local_docker_handler
 import os
-from backend.services.supabase import DBConnection # Adjusted import
+from ..services.supabase import DBConnection # Relative import
 from typing import Optional, Dict, List, Any # Added for wrapper classes
 
 # Define this at the module level or within the class if preferred,

--- a/backend/sandbox/tool_base.py
+++ b/backend/sandbox/tool_base.py
@@ -1,14 +1,14 @@
 
 from typing import Optional
 
-from backend.agentpress.thread_manager import ThreadManager # Adjusted import
-from backend.agentpress.tool import Tool # Adjusted import
+from ..agentpress.thread_manager import ThreadManager # Relative import
+from ..agentpress.tool import Tool # Relative import
 # Sandbox type can be Daytona's or our wrapper, so using Any for now, or a common base if defined
 from typing import Any
-from backend.sandbox.sandbox import get_or_start_sandbox # Adjusted import
-from backend.utils.logger import logger # Adjusted import
-from backend.utils.files_utils import clean_path # Adjusted import
-from backend.utils.config import config # Adjusted import
+from .sandbox import get_or_start_sandbox # Relative import
+from ..utils.logger import logger # Relative import
+from ..utils.files_utils import clean_path # Relative import
+from ..utils.config import config # Relative import
 
 class SandboxToolsBase(Tool):
     """Base class for all sandbox tools that provides project-based sandbox access."""

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -17,8 +17,8 @@ import asyncio
 import aiohttp # Added import
 from openai import OpenAIError
 import litellm
-from backend.utils.logger import logger # Adjusted import
-from backend.utils.config import config # Adjusted import
+from ..utils.logger import logger # Relative import
+from ..utils.config import config # Relative import
 
 # litellm.set_verbose=True
 litellm.modify_params=True

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -18,7 +18,7 @@ from functools import wraps
 import traceback
 from logging.handlers import RotatingFileHandler
 
-from backend.utils.config import config, EnvMode # Adjusted import
+from .config import config, EnvMode # Relative import
 
 # Context variable for request correlation ID
 request_id: ContextVar[str] = ContextVar('request_id', default='')

--- a/backend/utils/s3_upload_utils.py
+++ b/backend/utils/s3_upload_utils.py
@@ -5,8 +5,8 @@ Utility functions for handling image operations.
 import base64
 import uuid
 from datetime import datetime
-from backend.utils.logger import logger # Adjusted import
-from backend.services.supabase import DBConnection # Adjusted import
+from .logger import logger # Relative import
+from ..services.supabase import DBConnection # Relative import
 
 async def upload_base64_image(base64_data: str, bucket_name: str = "browser-screenshots") -> str:
     """Upload a base64 encoded image to Supabase storage and return the URL.


### PR DESCRIPTION
This commit fixes a `ModuleNotFoundError: No module named 'backend'` that occurred when running the application via gunicorn in Docker. The issue was caused by previous changes that used absolute imports (e.g., `from backend.services.llm`) which worked for tests run from the repository root but failed in the Docker runtime where the `/app` directory (corresponding to `backend/` from the repo) is the execution context.

Changes:
- Refactored import statements across the `backend` module (including `agentpress`, `services`, `utils`, `agent/tools`, `sandbox`) to use relative imports (e.g., `from ..services.llm`, `from ...agentpress.tool`).
- Verified that unit tests continue to pass with these changes, ensuring the `backend` package remains correctly importable for both runtime and testing.