### PR TITLE
Fix: Force direct imports in services/supabase.py

### DIFF
--- a/backend/services/supabase.py
+++ b/backend/services/supabase.py
@@ -4,8 +4,8 @@ Centralized database connection management for AgentPress using Supabase.
 
 from typing import Optional
 from supabase import create_async_client, AsyncClient
-from backend.utils.logger import logger # Adjusted import
-from backend.utils.config import config # Adjusted import
+from utils.logger import logger # Direct import
+from utils.config import config # Direct import
 import base64
 import uuid
 from datetime import datetime


### PR DESCRIPTION
This commit applies direct imports (e.g., `from utils.logger`) specifically to `backend/services/supabase.py`.
This is part of an iterative process to resolve runtime import errors in Docker.

The imports for `utils.logger` and `utils.config` have been corrected to use the direct style, consistent with changes made to `thread_manager.py`.