### PR TITLE
Refactor: Correct sb_files_tool.py based on issue report.

### DIFF
--- a/backend/agent/tools/sb_files_tool.py
+++ b/backend/agent/tools/sb_files_tool.py
@@ -291,7 +291,6 @@ class SandboxFilesTool(SandboxToolsBase):
                 return self.fail_response(f"File '{file_path}' does not exist. Use create_file to create a new file.")
             
             self.sandbox.fs.upload_file(full_path, file_contents.encode())
-            self.sandbox.fs.set_file_permissions(full_path, permissions)
             
             message = f"File '{file_path}' completely rewritten successfully."
             


### PR DESCRIPTION
- Verified that `create_file` method is `async def` and correctly awaits `sandbox.fs.upload_file`.
- Removed call to `self.sandbox.fs.set_file_permissions` from the `full_file_rewrite` method. This was the only identified instance of this call in the file.

These changes address the errors reported concerning async operations and file permissions in sb_files_tool.py.