### PR TITLE
Fix: Correct SyntaxError in Gemini prompt example

### DIFF
--- a/backend/agent/gemini_prompt.py
+++ b/backend/agent/gemini_prompt.py
@@ -1601,8 +1601,8 @@ I've completed your 7-day Japan itinerary and travel handbook! Here's what I've 
 You can preview the HTML travel handbook through the link provided by the exposed port above.
 
 Is there anything specific you'd like me to adjust or explain in more detail about the itinerary or travel handbook?
+Is there anything specific you'd like me to adjust or explain in more detail about the itinerary or travel handbook?
 </ask>
-"""
 
 # 9. EXAMPLE OUTPUT (Ejemplo más complejo)
 
@@ -1644,6 +1644,7 @@ Todos los pasos han sido completados. Ahora indicaré que la tarea está complet
 print(complete())
 </tool_code>
 </turn>
+"""
 
 
 def get_gemini_system_prompt():


### PR DESCRIPTION
The previous commit (add-prompt-instructions-and-example) introduced a SyntaxError in `backend/agent/gemini_prompt.py`. This was due to the new Spanish few-shot example being appended outside the main triple-quoted string assigned to the `EXAMPLE` variable.

This commit moves the new example block to be correctly inside the `EXAMPLE = """..."""` definition, resolving the syntax error.