### PR TITLE
fix: Correct syntax error in document_generation_tool.py

### DIFF
--- a/backend/agent/tools/document_generation_tool.py
+++ b/backend/agent/tools/document_generation_tool.py
@@ -341,11 +341,11 @@ async def main_test():
                 await asyncio.sleep(1) # Simulate time taken
                 return MockProc()
             elif "apt-get install" in command:
-                logger.info(f"MockSandbox: Simulating apt-get install for {command.split середній स्कूल 'install -y'}")
+                logger.info(f"MockSandbox: Simulating apt-get install for command: {command}")
                 await asyncio.sleep(1)
                 return MockProc()
             elif "python -m pip install" in command:
-                logger.info(f"MockSandbox: Simulating pip install for {command.split середній স্কুল 'install '}")
+                logger.info(f"MockSandbox: Simulating pip install for command: {command}")
                 await asyncio.sleep(1)
                 self._weasyprint_installed = "weasyprint" in command # Mark as installed
                 return MockProc()


### PR DESCRIPTION
This commit fixes a SyntaxError in `backend/agent/tools/document_generation_tool.py` that prevented the application from starting.

The error was caused by invalid `command.split` calls within f-strings in logging statements inside the `main_test()` example function. These lines contained extraneous text and incorrect syntax.

The fix replaces the faulty `split()` calls with direct logging of the `command` variable in the affected `logger.info` lines. This resolves the parsing error without affecting the core functionality of the SandboxDocumentGenerationTool, as the error was within non-executed test/example code.