### PR TITLE
fix: Downgrade FastAPI to resolve dependency conflict

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,7 +27,7 @@ e2b-code-interpreter==1.2.0
 entrypoints==0.4
 environs==9.5.0
 exa-py==1.12.0
-fastapi==0.110.0
+fastapi==0.100.1
 filelock==3.18.0
 frozenlist==1.5.0
 fsspec==2025.3.2


### PR DESCRIPTION
This commit downgrades FastAPI from version 0.110.0 to 0.100.1 in `backend/requirements.txt`.

This change was necessary to resolve a dependency conflict with the `agent-protocol` package. The `agent-protocol` package requires FastAPI version <0.101.0 and >=0.100.0.

Downgrading FastAPI allows `agent-protocol` to be installed and enables the successful integration and use of the document generation capabilities. Regression testing of existing FastAPI-dependent functionalities is recommended.