### PR TITLE
feat: Make Document Generation tool visible in Agent Tools Configuration

### DIFF
--- a/frontend/src/app/(dashboard)/agents/_data/tools.ts
+++ b/frontend/src/app/(dashboard)/agents/_data/tools.ts
@@ -7,6 +7,12 @@ export const DEFAULT_AGENTPRESS_TOOLS: Record<string, { enabled: boolean; descri
     'web_search_tool': { enabled: false, description: 'Search the web using Tavily API and scrape webpages with Firecrawl for research', icon: '🔍', color: 'bg-yellow-100 dark:bg-yellow-800/50' },
     'sb_vision_tool': { enabled: false, description: 'Vision and image processing capabilities for visual content analysis', icon: '👁️', color: 'bg-pink-100 dark:bg-pink-800/50' },
     'data_providers_tool': { enabled: false, description: 'Access to data providers and external APIs (requires RapidAPI key)', icon: '🔗', color: 'bg-cyan-100 dark:bg-cyan-800/50' },
+    'sb_document_generation_tool': {
+        enabled: false,
+        description: 'Generate documents (PDF, DOCX, HTML) with advanced formatting, manage templates, and convert between formats.',
+        icon: '📄',
+        color: 'bg-purple-100 dark:bg-purple-800/50'
+    },
 };
 
 export const getToolDisplayName = (toolName: string): string => {
@@ -19,6 +25,7 @@ export const getToolDisplayName = (toolName: string): string => {
       'web_search_tool': 'Web Search',
       'sb_vision_tool': 'Image Processing',
       'data_providers_tool': 'Data Providers',
+      'sb_document_generation_tool': 'Document Generation',
     };
     
     return displayNames[toolName] || toolName.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());


### PR DESCRIPTION
This commit updates the frontend to display the SandboxDocumentGenerationTool in the agent tools configuration UI (Agent Playground).

The tool was previously not visible because the UI populates the list of available AgentPress tools from a hardcoded object in `frontend/src/app/(dashboard)/agents/_data/tools.ts`.

Changes made:
- Added an entry for `sb_document_generation_tool` to the `DEFAULT_AGENTPRESS_TOOLS` object in `tools.ts`, including its default state, description, icon, and UI color.
- Added a corresponding display name "Document Generation" to the `getToolDisplayName` function in the same file.

This allows you to see and toggle the Document Generation tool when configuring my capabilities.