### PR TITLE
Fix: Register SandboxDocumentGenerationTool for custom agents

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -133,6 +133,9 @@ async def run_agent(
             thread_manager.add_tool(SandboxWebSearchTool, project_id=project_id, thread_manager=thread_manager)
         if enabled_tools.get('sb_vision_tool', {}).get('enabled', False):
             thread_manager.add_tool(SandboxVisionTool, project_id=project_id, thread_id=thread_id, thread_manager=thread_manager)
+        if enabled_tools.get('sandbox_document_generation_tool', {}).get('enabled', False):
+            thread_manager.add_tool(SandboxDocumentGenerationTool, project_id=project_id, thread_manager=thread_manager)
+            logger.info("Registered SandboxDocumentGenerationTool for custom agent.") # Optional: Add a log
         if config.RAPID_API_KEY and enabled_tools.get('data_providers_tool', {}).get('enabled', False):
             thread_manager.add_tool(DataProvidersTool)
 


### PR DESCRIPTION
The SandboxDocumentGenerationTool was previously only registered when no specific agent configuration was active. This meant that if you configured a custom agent , the Document Generation Tool would appear in the UI but would not be available for me to use at runtime, as it was never registered in such cases.

This commit updates the system to include a check for `sandbox_document_generation_tool` within the logic that handles custom agent configurations. If the tool is
enabled in the agent's configuration, it is now correctly registered. This ensures the tool is available for me to use with custom agents as intended.