### PR TITLE
Fix: Add missing ToolView components for DeepResearch and WebsiteCrea…

### DIFF
--- a/frontend/src/components/thread/tool-views/DeepResearchToolView.tsx
+++ b/frontend/src/components/thread/tool-views/DeepResearchToolView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { ToolViewProps } from './types';
+
+export const DeepResearchToolView: React.FC<ToolViewProps> = ({ toolCall }) => {
+  return (
+    <div>
+      <h3>Deep Research Tool</h3>
+      <p>Tool call ID: {toolCall.id}</p>
+      <p>Status: {toolCall.status}</p>
+      {/* Add more detailed view based on toolCall.input and toolCall.output */}
+    </div>
+  );
+};
+
+export default DeepResearchToolView;

--- a/frontend/src/components/thread/tool-views/WebsiteCreatorToolView.tsx
+++ b/frontend/src/components/thread/tool-views/WebsiteCreatorToolView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { ToolViewProps } from './types';
+
+export const WebsiteCreatorToolView: React.FC<ToolViewProps> = ({ toolCall }) => {
+  return (
+    <div>
+      <h3>Website Creator Tool</h3>
+      <p>Tool call ID: {toolCall.id}</p>
+      <p>Status: {toolCall.status}</p>
+      {/* Add more detailed view based on toolCall.input and toolCall.output */}
+    </div>
+  );
+};
+
+export default WebsiteCreatorToolView;


### PR DESCRIPTION
…tor tools

This commit adds the previously missing React component files for DeepResearchToolView and WebsiteCreatorToolView. Their absence caused the build to fail.

- I created `frontend/src/components/thread/tool-views/DeepResearchToolView.tsx` with placeholder content.
- I created `frontend/src/components/thread/tool-views/WebsiteCreatorToolView.tsx` with placeholder content.

The `ToolViewRegistry.tsx` was already updated in a previous commit to import these components directly. This commit provides the actual files, resolving the module not found errors.