### PR TITLE
Fix: Update ToolView components to use correct props

### DIFF
--- a/frontend/src/components/thread/tool-views/DeepResearchToolView.tsx
+++ b/frontend/src/components/thread/tool-views/DeepResearchToolView.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import { ToolViewProps } from './types';
 
-export const DeepResearchToolView: React.FC<ToolViewProps> = ({ toolCall }) => {
+export const DeepResearchToolView: React.FC<ToolViewProps> = ({
+  name,
+  agentStatus,
+  isSuccess,
+  assistantContent,
+  toolContent,
+}) => {
   return (
     <div>
       <h3>Deep Research Tool</h3>
-      <p>Tool call ID: {toolCall.id}</p>
-      <p>Status: {toolCall.status}</p>
-      {/* Add more detailed view based on toolCall.input and toolCall.output */}
+      <p>Tool Name/ID: {name || 'N/A'}</p>
+      <p>Status: {agentStatus || (isSuccess ? 'Completed' : 'Unknown')}</p>
+      {assistantContent && <p>Assistant Content: {assistantContent}</p>}
+      {toolContent && <p>Tool Content: {toolContent}</p>}
+      {/* Add more detailed view based on available props */}
     </div>
   );
 };

--- a/frontend/src/components/thread/tool-views/WebsiteCreatorToolView.tsx
+++ b/frontend/src/components/thread/tool-views/WebsiteCreatorToolView.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import { ToolViewProps } from './types';
 
-export const WebsiteCreatorToolView: React.FC<ToolViewProps> = ({ toolCall }) => {
+export const WebsiteCreatorToolView: React.FC<ToolViewProps> = ({
+  name,
+  agentStatus,
+  isSuccess,
+  assistantContent,
+  toolContent,
+}) => {
   return (
     <div>
       <h3>Website Creator Tool</h3>
-      <p>Tool call ID: {toolCall.id}</p>
-      <p>Status: {toolCall.status}</p>
-      {/* Add more detailed view based on toolCall.input and toolCall.output */}
+      <p>Tool Name/ID: {name || 'N/A'}</p>
+      <p>Status: {agentStatus || (isSuccess ? 'Completed' : 'Unknown')}</p>
+      {assistantContent && <p>Assistant Content: {assistantContent}</p>}
+      {toolContent && <p>Tool Content: {toolContent}</p>}
+      {/* Add more detailed view based on available props */}
     </div>
   );
 };


### PR DESCRIPTION
This commit fixes a TypeScript error in DeepResearchToolView and WebsiteCreatorToolView components. The error occurred because the components were trying to access a 'toolCall' property which does not exist on the ToolViewProps type.

The components have been updated to destructure and use the correct individual properties from ToolViewProps (e.g., name, agentStatus, isSuccess, assistantContent, toolContent).