### PR TITLE
Fix: Correct ImportError for DocumentGenerationTool

### DIFF
--- a/backend/agent/tools/__init__.py
+++ b/backend/agent/tools/__init__.py
@@ -1,7 +1,7 @@
 from agentpress.tool import Tool
 from .continue_task_tool import ContinueTaskTool
 from .data_providers_tool import DataProvidersTool
-from .document_generation_tool import DocumentGenerationTool
+from .document_generation_tool import SandboxDocumentGenerationTool
 from .expand_msg_tool import ExpandMsgTool
 from .message_tool import MessageTool
 from .sb_browser_tool import ComputerUseTool
@@ -20,7 +20,7 @@ default_tools: list[Tool] = [
     UpdateAgentTool(),
     DataProvidersTool(),
     ExpandMsgTool(),
-    DocumentGenerationTool(),
+    SandboxDocumentGenerationTool(), # Corrected
     # INICIO DE MODIFICACIÓN
     SandboxDeepResearchTool(),
     SandboxWebsiteCreatorTool(),


### PR DESCRIPTION
The application was crashing due to an ImportError for DocumentGenerationTool. This was caused by an incorrect class name in the import statement and instantiation within `backend/agent/tools/__init__.py`.

The class defined in `document_generation_tool.py` is `SandboxDocumentGenerationTool`, but `__init__.py` was attempting to import and use `DocumentGenerationTool`.

This commit updates `backend/agent/tools/__init__.py` to correctly import and instantiate `SandboxDocumentGenerationTool`.