### PR TITLE
Fix: Correct ImportError for ExpandMessageTool

### DIFF
--- a/backend/agent/tools/__init__.py
+++ b/backend/agent/tools/__init__.py
@@ -2,7 +2,7 @@ from agentpress.tool import Tool
 from .continue_task_tool import ContinueTaskTool
 from .data_providers_tool import DataProvidersTool
 from .document_generation_tool import SandboxDocumentGenerationTool
-from .expand_msg_tool import ExpandMsgTool
+from .expand_msg_tool import ExpandMessageTool
 from .message_tool import MessageTool
 from .sb_browser_tool import ComputerUseTool
 from .update_agent_tool import UpdateAgentTool
@@ -19,7 +19,7 @@ default_tools: list[Tool] = [
     MessageTool(),
     UpdateAgentTool(),
     DataProvidersTool(),
-    ExpandMsgTool(),
+    ExpandMessageTool(), # Corrected
     SandboxDocumentGenerationTool(), # Corrected
     # INICIO DE MODIFICACIÓN
     SandboxDeepResearchTool(),


### PR DESCRIPTION
The application was crashing due to an ImportError for ExpandMsgTool. This was caused by an incorrect class name in the import statement and instantiation.

The class defined in `expand_msg_tool.py` is `ExpandMessageTool`, but it was being imported and used as `ExpandMsgTool`.

This commit updates the import and instantiation to correctly use `ExpandMessageTool`.