### PR TITLE
Fix: Add missing agent_protocol dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -56,6 +56,7 @@ langfuse = "^2.60.5"
 Pillow = "^10.0.0"
 mcp = "^1.0.0"
 sentry-sdk = {extras = ["fastapi"], version = "^2.29.1"}
+agent_protocol = "*" # Add this line. Using "*" for now as version is unknown.
 docker = "*"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
The backend was failing with a ModuleNotFoundError for 'agent_protocol'. This module is a required dependency for the newly added SandboxDeepResearchTool and SandboxWebsiteCreatorTool.

This commit adds 'agent_protocol = "*"' to the [tool.poetry.dependencies] section of `backend/pyproject.toml` to ensure it's installed as part of the backend environment.