### PR TITLE
Fix: Correct agent_protocol imports and remove unnecessary dependency

### DIFF
--- a/backend/agent/tools/deep_research_tool_updated.py
+++ b/backend/agent/tools/deep_research_tool_updated.py
@@ -5,11 +5,7 @@ import asyncio
 from typing import Dict, List, Any, Optional, Union
 from datetime import datetime
 
-from agent_protocol import Tool, ToolResult
-from agent_protocol.models import (
-    openapi_schema,
-    xml_schema,
-)
+from agentpress.tool import Tool, ToolResult, openapi_schema, xml_schema
 from sandbox.tool_base import SandboxToolsBase
 from agentpress.thread_manager import ThreadManager
 

--- a/backend/agent/tools/website_creator_tool_updated.py
+++ b/backend/agent/tools/website_creator_tool_updated.py
@@ -5,11 +5,7 @@ import asyncio
 from typing import Dict, List, Any, Optional, Union
 from datetime import datetime
 
-from agent_protocol import Tool, ToolResult
-from agent_protocol.models import (
-    openapi_schema,
-    xml_schema,
-)
+from agentpress.tool import Tool, ToolResult, openapi_schema, xml_schema
 from sandbox.tool_base import SandboxToolsBase
 from agentpress.thread_manager import ThreadManager
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -56,7 +56,6 @@ langfuse = "^2.60.5"
 Pillow = "^10.0.0"
 mcp = "^1.0.0"
 sentry-sdk = {extras = ["fastapi"], version = "^2.29.1"}
-agent_protocol = "*" # Add this line. Using "*" for now as version is unknown.
 docker = "*"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
This commit resolves the ModuleNotFoundError for 'agent_protocol'. The new tools (SandboxDeepResearchTool and SandboxWebsiteCreatorTool) were incorrectly trying to import from a non-existent 'agent_protocol' module.

The fix involves:
1. Modifying `deep_research_tool_updated.py` and `website_creator_tool_updated.py` to import `Tool`, `ToolResult`, `openapi_schema`, and `xml_schema` from the existing local module `agentpress.tool`.
2. Removing the erroneous `agent_protocol = "*"` line that was previously added to `backend/pyproject.toml`.

This ensures the tools use the correct internal modules and avoids build failures due to missing dependencies.