### PR TITLE
Fix: Correct AttributeError for SandboxFileOperationMixin

### DIFF
--- a/backend/agent/tools/deep_research_tool_updated.py
+++ b/backend/agent/tools/deep_research_tool_updated.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Any, Optional, Union
 from datetime import datetime
 
 from agentpress.tool import Tool, ToolResult, openapi_schema, xml_schema
-from sandbox.tool_base import SandboxToolsBase
 from agentpress.thread_manager import ThreadManager
 
 # Import necessary tools that we'll use
@@ -17,7 +16,7 @@ from agent.tools.document_generation_tool import SandboxDocumentGenerationTool
 logger = logging.getLogger(__name__)
 
 @openapi_schema
-class SandboxDeepResearchToolParameters(SandboxToolsBase.SandboxFileOperationMixin):
+class SandboxDeepResearchToolParameters:
     """
     Parameters for the SandboxDeepResearchTool.
     """
@@ -45,7 +44,7 @@ class SandboxDeepResearchToolParameters(SandboxToolsBase.SandboxFileOperationMix
         extra = "forbid"
 
 @openapi_schema
-class SandboxDeepResearchToolOutput(SandboxToolsBase.SandboxFileOperationMixin):
+class SandboxDeepResearchToolOutput:
     """
     Output for the SandboxDeepResearchTool.
     """

--- a/backend/agent/tools/website_creator_tool_updated.py
+++ b/backend/agent/tools/website_creator_tool_updated.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Any, Optional, Union
 from datetime import datetime
 
 from agentpress.tool import Tool, ToolResult, openapi_schema, xml_schema
-from sandbox.tool_base import SandboxToolsBase
 from agentpress.thread_manager import ThreadManager
 
 # Import necessary tools that we'll use
@@ -17,7 +16,7 @@ from agent.tools.sb_deploy_tool import SandboxDeployTool
 logger = logging.getLogger(__name__)
 
 @openapi_schema
-class SandboxWebsiteCreatorToolParameters(SandboxToolsBase.SandboxFileOperationMixin):
+class SandboxWebsiteCreatorToolParameters:
     """
     Parameters for the SandboxWebsiteCreatorTool.
     """
@@ -49,7 +48,7 @@ class SandboxWebsiteCreatorToolParameters(SandboxToolsBase.SandboxFileOperationM
         extra = "forbid"
 
 @openapi_schema
-class SandboxWebsiteCreatorToolOutput(SandboxToolsBase.SandboxFileOperationMixin):
+class SandboxWebsiteCreatorToolOutput:
     """
     Output for the SandboxWebsiteCreatorTool.
     """


### PR DESCRIPTION
This commit resolves an AttributeError in the new tool definitions: 'type object 'SandboxToolsBase' has no attribute 'SandboxFileOperationMixin''.

The parameter and output classes (e.g., SandboxDeepResearchToolParameters) in `deep_research_tool_updated.py` and `website_creator_tool_updated.py` were incorrectly trying to inherit from a non-existent mixin `SandboxToolsBase.SandboxFileOperationMixin`.

This commit corrects the class definitions by removing this faulty inheritance. The associated `@openapi_schema` decorators are expected to handle the necessary schema definitions for these data classes. Unused imports of `SandboxToolsBase` in these files were also removed.