### PR TITLE
Fix: Correct TypeError for Tool class inheritance

### DIFF
--- a/backend/agent/tools/deep_research_tool_updated.py
+++ b/backend/agent/tools/deep_research_tool_updated.py
@@ -47,7 +47,7 @@ class SandboxDeepResearchToolOutput:
     class Config:
         extra = "forbid"
 
-class SandboxDeepResearchTool(Tool[SandboxDeepResearchToolParameters, SandboxDeepResearchToolOutput]):
+class SandboxDeepResearchTool(Tool):
     """Tool for performing deep research on topics by combining web search, content analysis, and information synthesis."""
 
     name = "SandboxDeepResearchTool"

--- a/backend/agent/tools/website_creator_tool_updated.py
+++ b/backend/agent/tools/website_creator_tool_updated.py
@@ -49,7 +49,7 @@ class SandboxWebsiteCreatorToolOutput:
     class Config:
         extra = "forbid"
 
-class SandboxWebsiteCreatorTool(Tool[SandboxWebsiteCreatorToolParameters, SandboxWebsiteCreatorToolOutput]):
+class SandboxWebsiteCreatorTool(Tool):
     """Tool for creating basic website structures within the sandbox environment."""
 
     name = "SandboxWebsiteCreatorTool"


### PR DESCRIPTION
This commit resolves a TypeError: 'type' object is not subscriptable, which occurred during the definition of SandboxDeepResearchTool and SandboxWebsiteCreatorTool classes.

The base class `agentpress.tool.Tool` is not a generic type and cannot be subscripted with type parameters (e.g., Tool[Params, Output]).

This commit modifies the class definitions in:
- `backend/agent/tools/deep_research_tool_updated.py`
- `backend/agent/tools/website_creator_tool_updated.py`

The inheritance is changed to directly inherit from `Tool` (e.g., `class SandboxDeepResearchTool(Tool):`). The association with parameter and output schemas is handled by the existing `parameters_schema` and `output_schema` class attributes.