### PR TITLE
Feat: Fully integrate Deep Research tool (backend and frontend)

### DIFF
--- a/backend/agent/tools/__init__.py
+++ b/backend/agent/tools/__init__.py
@@ -7,7 +7,7 @@ from .message_tool import MessageTool
 from .sb_browser_tool import SandboxBrowserTool # Was ComputerUseTool
 from .update_agent_tool import UpdateAgentTool
 from .web_search_tool import SandboxWebSearchTool # Was WebSearchTool
-from .deep_research_tool_updated import SandboxDeepResearchTool # New
+from .deep_research_tool_updated import DeepResearchToolUpdated # New
 from .website_creator_tool_updated import SandboxWebsiteCreatorTool # New
 
 default_tools: list[Tool] = [
@@ -17,7 +17,7 @@ default_tools: list[Tool] = [
     MessageTool(),                # Correct
     DataProvidersTool(),          # Correct
     SandboxDocumentGenerationTool(),# Already Corrected
-    SandboxDeepResearchTool(),    # New
+    DeepResearchToolUpdated(),    # New
     SandboxWebsiteCreatorTool(),  # New
 ]
 

--- a/backend/agent/tools/deep_research_tool_updated.py
+++ b/backend/agent/tools/deep_research_tool_updated.py
@@ -16,9 +16,9 @@ from agent.tools.document_generation_tool import SandboxDocumentGenerationTool
 logger = logging.getLogger(__name__)
 
 @openapi_schema
-class SandboxDeepResearchToolParameters:
+class DeepResearchToolUpdatedParameters:
     """
-    Parameters for the SandboxDeepResearchTool.
+    Parameters for the DeepResearchToolUpdated.
     """
     # Description: The research topic or question to investigate in detail.
     topic: str
@@ -33,9 +33,9 @@ class SandboxDeepResearchToolParameters:
         extra = "forbid"
 
 @openapi_schema
-class SandboxDeepResearchToolOutput:
+class DeepResearchToolUpdatedOutput:
     """
-    Output for the SandboxDeepResearchTool.
+    Output for the DeepResearchToolUpdated.
     """
     # Description: The path to the generated research report within the sandbox environment.
     report_path: str
@@ -47,16 +47,16 @@ class SandboxDeepResearchToolOutput:
     class Config:
         extra = "forbid"
 
-class SandboxDeepResearchTool(Tool):
+class DeepResearchToolUpdated(Tool):
     """Tool for performing deep research on topics by combining web search, content analysis, and information synthesis."""
 
-    name = "DeepSearchTool"
+    name = "DeepResearch"
     description = (
         "A tool for performing deep research on topics by searching multiple sources, "
         "analyzing content, and synthesizing information into a comprehensive report."
     )
-    parameters_schema = SandboxDeepResearchToolParameters
-    output_schema = SandboxDeepResearchToolOutput
+    parameters_schema = DeepResearchToolUpdatedParameters
+    output_schema = DeepResearchToolUpdatedOutput
 
     # NOTE: project_id, thread_manager (and thread_id if applicable) are Optional to allow default instantiation.
     def __init__(
@@ -117,14 +117,14 @@ class SandboxDeepResearchTool(Tool):
         return self._sandbox
 
     @xml_schema(
-        tag_name="deep_search",
+        tag_name="deep-research",
         # Parameters are passed as a Pydantic model 'parameters',
         # so explicit mapping for each field might not be needed here
         # if the framework handles Pydantic models automatically with openapi_schema.
         # The example will show how parameters are expected within the 'parameters' object.
         example='''
         <function_calls>
-          <invoke name="deep_search">
+          <invoke name="deep-research">
             <parameters>
               <topic>Future of renewable energy</topic>
               <depth>standard</depth>
@@ -135,7 +135,7 @@ class SandboxDeepResearchTool(Tool):
         </function_calls>
         '''
     )
-    async def run(self, parameters: SandboxDeepResearchToolParameters) -> List[ToolResult]:
+    async def run(self, parameters: DeepResearchToolUpdatedParameters) -> List[ToolResult]:
         """
         Perform deep research on a topic by searching multiple sources, analyzing content, and synthesizing information.
 
@@ -192,7 +192,7 @@ class SandboxDeepResearchTool(Tool):
             # Return success with the report path and metadata
             return [
                 ToolResult(
-                    output=SandboxDeepResearchToolOutput(
+                    output=DeepResearchToolUpdatedOutput(
                         report_path=report_path,
                         message=f"Research on '{parameters.topic}' completed successfully.",
                         sources_analyzed=len(analyzed_content),

--- a/frontend/src/app/(dashboard)/agents/_data/tools.ts
+++ b/frontend/src/app/(dashboard)/agents/_data/tools.ts
@@ -17,6 +17,7 @@ export const DEFAULT_AGENTPRESS_TOOLS: Record<string, { enabled: boolean; descri
     'deep_researcher': { enabled: false, description: 'Performs deep research on a topic and generates a report.', icon: '📚', color: 'bg-teal-100 dark:bg-teal-800/50' },
     'website_creator': { enabled: false, description: 'Creates and deploys a complete website from a description.', icon: '🛠️', color: 'bg-sky-100 dark:bg-sky-800/50' },
     // FIN DE MODIFICACIÓN
+    'DeepResearchToolUpdated': { enabled: false, description: 'Realiza una investigación profunda y exhaustiva sobre un tema.', icon: '📚', color: 'bg-lime-100 dark:bg-lime-800/50' },
 };
 
 export const getToolDisplayName = (toolName: string): string => {
@@ -34,6 +35,7 @@ export const getToolDisplayName = (toolName: string): string => {
       'deep_researcher': 'Deep Research',
       'website_creator': 'Website Creator',
       // FIN DE MODIFICACIÓN
+      'DeepResearchToolUpdated': 'Deep Research',
     };
     
     return displayNames[toolName] || toolName.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());

--- a/frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx
+++ b/frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx
@@ -76,6 +76,7 @@ const defaultRegistry: ToolViewRegistryType = {
   'document-generation': DocumentGenerationToolView, // Fallback or alternative name
   // INICIO DE MODIFICACIÓN
   'deep_researcher': DeepResearchToolView,
+  'deep-research': DeepResearchToolView, // Added new entry
   'website_creator': WebsiteCreatorToolView,
   // FIN DE MODIFICACIÓN
 


### PR DESCRIPTION
This commit integrates the 'DeepResearchToolUpdated' across both backend and frontend based on further requirements.

Backend changes (`backend/agent/tools/`):
- Renamed the tool class to `DeepResearchToolUpdated` in `deep_research_tool_updated.py`.
- Renamed associated parameter and output schema classes.
- Set the internal `name` attribute to "DeepResearch".
- Configured `@xml_schema` on the `run` method with `tag_name="deep-research"` for my invocation.
- Updated `__init__.py` to correctly import and register `DeepResearchToolUpdated`.

Frontend changes:
- In `frontend/src/app/(dashboard)/agents/_data/tools.ts`:
  - Added `DeepResearchToolUpdated` to the `DEFAULT_AGENTPRESS_TOOLS` map, including default `enabled: false`, an icon (📚), description, and color.
  - Mapped its display name 'Deep Research' in `getToolDisplayName`.
- In `frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx`:
  - Registered `DeepResearchToolView` with the key 'deep-research' to link the backend tool tag with its frontend view component.

These changes ensure the tool is discoverable by me, invokable via the correct XML tag, and its UI elements are correctly defined and registered in the frontend.