### PR TITLE
Feat: Add diagnostic logging for custom agent tool configurations

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -118,6 +118,7 @@ async def run_agent(
             thread_manager.add_tool(DataProvidersTool)
     else:
         logger.info("Custom agent specified - registering only enabled tools")
+        logger.info(f"DEBUG: enabled_tools for custom agent: {enabled_tools}")
         thread_manager.add_tool(ExpandMessageTool, thread_id=thread_id, thread_manager=thread_manager)
         thread_manager.add_tool(MessageTool)
         thread_manager.add_tool(ContinueTaskTool)
@@ -138,6 +139,7 @@ async def run_agent(
         if enabled_tools.get('sandbox_document_generation_tool', {}).get('enabled', False): # Note: Key might be 'sb_document_generation_tool' based on tools.ts
             thread_manager.add_tool(SandboxDocumentGenerationTool, project_id=project_id, thread_manager=thread_manager)
             logger.info("Registered SandboxDocumentGenerationTool for custom agent.")
+        logger.info(f"DEBUG: Value of enabled_tools.get('deep_research_tool_updated', {{}}): {enabled_tools.get('deep_research_tool_updated', {})}")
         if enabled_tools.get('deep_research_tool_updated', {}).get('enabled', False): # Key changed here
             thread_manager.add_tool(DeepResearchToolUpdated, project_id=project_id, thread_manager=thread_manager)
             logger.info("Registered DeepResearchToolUpdated for custom agent.")


### PR DESCRIPTION
Adds logging statements to `backend/agent/run.py` within the `run_agent` function to aid in debugging custom agent tool setups.

Specifically, when a custom agent's tools are being processed:
1. Logs the entire `enabled_tools` dictionary.
2. Logs the specific value retrieved for the key 'deep_research_tool_updated' from `enabled_tools`.

This will help you verify the tool configuration being loaded for custom agents and diagnose issues if a specific tool, like DeepResearchToolUpdated, is not being registered as expected.