### PR TITLE
Fix: Align DeepResearchToolUpdated key to existing agent config

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -139,8 +139,8 @@ async def run_agent(
         if enabled_tools.get('sandbox_document_generation_tool', {}).get('enabled', False): # Note: Key might be 'sb_document_generation_tool' based on tools.ts
             thread_manager.add_tool(SandboxDocumentGenerationTool, project_id=project_id, thread_manager=thread_manager)
             logger.info("Registered SandboxDocumentGenerationTool for custom agent.")
-        logger.info(f"DEBUG: Value of enabled_tools.get('deep_research_tool_updated', {{}}): {enabled_tools.get('deep_research_tool_updated', {})}")
-        if enabled_tools.get('deep_research_tool_updated', {}).get('enabled', False): # Key changed here
+        logger.info(f"DEBUG: Value of enabled_tools.get('DeepResearchToolUpdated', {{}}): {enabled_tools.get('DeepResearchToolUpdated', {})}")
+        if enabled_tools.get('DeepResearchToolUpdated', {}).get('enabled', False): # Key changed back here
             thread_manager.add_tool(DeepResearchToolUpdated, project_id=project_id, thread_manager=thread_manager)
             logger.info("Registered DeepResearchToolUpdated for custom agent.")
         if config.RAPID_API_KEY and enabled_tools.get('data_providers_tool', {}).get('enabled', False):


### PR DESCRIPTION
Reverts the lookup key for DeepResearchToolUpdated in `backend/agent/run.py` back to PascalCase ('DeepResearchToolUpdated') when processing custom agent tool configurations.

This change is made to match the existing configuration format observed in your logs for the 'Mitosis' agent, where the tool is enabled under the key 'DeepResearchToolUpdated'.

The associated diagnostic log was also updated to use the PascalCase key. This should allow the tool to be correctly identified as enabled and subsequently registered by AgentPress for the 'Mitosis' agent.