### PR TITLE
This commit adds debug logging to help with understanding the executi…

### DIFF
--- a/backend/agentpress/response_processor.py
+++ b/backend/agentpress/response_processor.py
@@ -1324,6 +1324,7 @@ class ResponseProcessor:
     # Tool execution methods
     async def _execute_tool(self, tool_call: Dict[str, Any]) -> ToolResult:
         """Execute a single tool call and return the result."""
+        logger.debug(f"Executing tool with tool_call data: {tool_call}")
         # Ensure original_function_name is available for span naming even if tool_call is malformed
         original_function_name_for_span = tool_call.get("function_name", "unknown_tool")
         span = self.trace.span(name=f"execute_tool.{original_function_name_for_span}", input=tool_call.get("arguments"))

--- a/backend/agentpress/tool_registry.py
+++ b/backend/agentpress/tool_registry.py
@@ -118,7 +118,9 @@ class ToolRegistry:
         Returns:
             Dict containing tool instance, method name, and schema
         """
+        logger.debug(f"Attempting to get XML tool for tag: '{tag_name}'. Available XML tags: {list(self.xml_tools.keys())}")
         tool = self.xml_tools.get(tag_name, {})
+        logger.debug(f"Retrieved tool info for tag '{tag_name}': {tool}")
         if not tool:
             logger.warning(f"XML tool not found for tag: {tag_name}")
         return tool


### PR DESCRIPTION
…on flow of the deep_search tool. This will be useful in diagnosing issues related to its operation.

The changes include:
- Logging in `ToolRegistry.get_xml_tool` to display the available XML tags and the outcome when attempting to retrieve a tool using a specific tag.
- Logging in `ResponseProcessor._execute_tool` to show the precise `tool_call` data that is being handled.