### PR TITLE
Fix: Align deep_search XML tag name for registration and lookup

### DIFF
--- a/backend/agent/tools/deep_research_tool_updated.py
+++ b/backend/agent/tools/deep_research_tool_updated.py
@@ -117,7 +117,7 @@ class DeepResearchToolUpdated(Tool):
         return self._sandbox
 
     @xml_schema(
-        tag_name="deep_search",
+        tag_name="deep-search",
         # Parameters are passed as a Pydantic model 'parameters',
         # so explicit mapping for each field might not be needed here
         # if the framework handles Pydantic models automatically with openapi_schema.


### PR DESCRIPTION
I changed the tag_name in the @xml_schema decorator for DeepResearchToolUpdated from "deep_search" (underscore) to "deep-search" (hyphen). This ensures the tool is registered with the same tag name that is parsed from the LLM's XML, resolving the tool not found error.