### PR TITLE
Fix: Increase pip timeout and install numpy separately in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,8 @@ RUN useradd -m -u 1000 appuser && \
 
 # Install Python dependencies
 COPY --chown=appuser:appuser requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt gunicorn
+RUN pip install --no-cache-dir --timeout 600 numpy
+RUN pip install --no-cache-dir --timeout 600 -r requirements.txt gunicorn
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
This commit addresses a ReadTimeoutError that occurred during `pip install` in the Docker build process.

Changes made:
- NumPy is now installed in a separate RUN command before other dependencies. This helps to isolate potential issues with this specific package.
- The `--timeout 600` option has been added to both pip install commands (for numpy and for the rest of the requirements) to give pip more time to download packages, which can be helpful on slower or less stable network connections.