### PR TITLE
feat: Refactor agent thought display with collapsible ReasoningView

### DIFF
--- a/frontend/src/components/thread/ReasoningView.tsx
+++ b/frontend/src/components/thread/ReasoningView.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { Markdown } from '@/components/ui/markdown'; // Reutilizamos el componente de Markdown
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from '../ui/collapsible';
 
 interface ReasoningViewProps {
   content: string;
@@ -11,9 +16,13 @@ export const ReasoningView: React.FC<ReasoningViewProps> = ({ content }) => {
   }
 
   return (
-    <div className="border-l-4 border-blue-500 pl-4 py-2 my-4 bg-blue-50 dark:bg-gray-800">
-      <h3 className="font-semibold text-lg mb-2 text-blue-800 dark:text-blue-300">Plan de Acción</h3>
-      <Markdown>{content}</Markdown>
-    </div>
+    <Collapsible>
+      <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg">
+        <CollapsibleTrigger>Pensamiento del Agente</CollapsibleTrigger>
+        <CollapsibleContent>
+          <Markdown>{content}</Markdown>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
   );
 };


### PR DESCRIPTION
Modifies the frontend to change how my thoughts, enclosed in <think> tags, are visualized.

Previously, content within <think>...</think> tags was rendered as plain text directly in the chat.

This commit introduces the following changes:

1.  **Updated `ReasoningView.tsx`**:
    *   The component is now wrapped in a `Collapsible` element from `collapsible.tsx`.
    *   A `CollapsibleTrigger` displays the title "Pensamiento del Agente".
    *   My thought content is displayed within `CollapsibleContent`.
    *   The component has new styling: `bg-slate-100 dark:bg-slate-800`, `p-4`, and `rounded-lg`.

2.  **Modified `markdown.tsx`**:
    *   The component now preprocesses the markdown input to find `<think>...</think>` tags.
    *   Content from these tags is extracted.
    *   The tags themselves are replaced with unique placeholder paragraphs.
    *   A custom paragraph renderer detects these placeholders and renders the extracted content using the `ReasoningView` component.
    *   The `parseMarkdownIntoBlocks` function was removed to simplify this new rendering logic.

This change ensures that my thoughts are visually distinct from the main conversation, presented in a styled, collapsible section, improving your experience by making the chat flow cleaner and my reasoning process accessible yet unobtrusive.