### PR TITLE
fix: Robustly render user-provided P components in Markdown

### DIFF
--- a/frontend/src/components/ui/markdown.tsx
+++ b/frontend/src/components/ui/markdown.tsx
@@ -217,10 +217,12 @@ function MarkdownComponent({
         }
 
         // It's not a thought placeholder, render a normal paragraph or user-defined component
-        if (propComponents?.p && typeof propComponents.p === 'function') {
-          return propComponents.p({ node, children: pChildren, ...props });
+        if (propComponents?.p && typeof propComponents.p !== 'string') {
+          // propComponents.p is a custom component (function or class)
+          const UserP = propComponents.p;
+          return <UserP node={node} {...props}>{pChildren}</UserP>;
         }
-        // If propComponents.p is not a function (e.g., undefined or a string like "p"),
+        // If propComponents.p is undefined or a string (like "p"),
         // render a standard HTML paragraph.
         return <p {...props}>{pChildren}</p>;
       },


### PR DESCRIPTION
Revises the custom paragraph renderer in `frontend/src/components/ui/markdown.tsx` to correctly handle user-provided components (both functional and class-based).

Instead of attempting a direct function call on `propComponents.p`, this commit ensures that if `propComponents.p` is a valid React component type (not a string), it is rendered using JSX syntax (`<UserP ...>`). This is the standard and more robust way to render React components and should prevent the recurring "not callable" type error.

If `propComponents.p` is not provided or is a string (indicating default HTML rendering), a standard `<p>` tag is rendered.