### PR TITLE
fix: Add missing useCallback import in use-cached-file.ts

### DIFF
--- a/frontend/src/hooks/use-cached-file.ts
+++ b/frontend/src/hooks/use-cached-file.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react'; // Added useCallback
 import { useAuth } from '@/components/AuthProvider';
 
 // Global cache to persist between component mounts


### PR DESCRIPTION
Adds `useCallback` to the React import statement in `frontend/src/hooks/use-cached-file.ts`.

This was an oversight from previous refactoring where `useCallback` was used to wrap internal functions (`getCachedFile`, `getFileContent`) for `exhaustive-deps` correctness, but the import itself was missed, leading to a "Cannot find name 'useCallback'" build error.