### PR TITLE
fix: Trim potential ID in Markdown paragraph renderer

### DIFF
--- a/frontend/src/components/ui/markdown.tsx
+++ b/frontend/src/components/ui/markdown.tsx
@@ -212,7 +212,7 @@ function MarkdownComponent({
         // Ensure pChildren is a flat string if it's a simple text node,
         // ReactMarkdown might pass an array with one string.
         const childTextNode = Array.isArray(pChildren) ? pChildren[0] : pChildren;
-        const potentialId = typeof childTextNode === 'string' ? childTextNode : '';
+        const potentialId = typeof childTextNode === 'string' ? childTextNode.trim() : '';
 
         const thought = extractedThoughts.find(t => t.id === potentialId);
         if (thought) {


### PR DESCRIPTION
Modifies the custom paragraph renderer in
`frontend/src/components/ui/markdown.tsx` to trim whitespace from the `potentialId` before matching against `extractedThoughts`.

This makes the matching of placeholder IDs (e.g., "reasoning-view-0") more robust by accounting for any potential leading/trailing whitespace that might be introduced when ReactMarkdown parses the placeholder paragraph string (e.g., "<p> id </p>").

This change helps ensure that placeholder paragraphs are correctly replaced by `ReasoningView` components.