### PR TITLE
fix: Correct duplicate variable declaration in ThreadContent

### DIFF
--- a/frontend/src/components/thread/content/ThreadContent.tsx
+++ b/frontend/src/components/thread/content/ThreadContent.tsx
@@ -719,8 +719,9 @@ export const ThreadContent: React.FC<ThreadContentProps> = ({
                                                                         // we strip them here before passing to Markdown for the main assistant speech.
                                                                         const strippedStreamingText = rawStreamingText.replace(/<think>((?:.|\n)*?)<\/think>/gi, '');
 
-                                                                        let detectedTag: string | null = null;
-                                                                        let tagStartIndex = -1;
+                                                                        // Corrected: Re-assign to existing variables, do not re-declare
+                                                                        detectedTag = null;
+                                                                        tagStartIndex = -1;
                                                                         if (strippedStreamingText) { // Check on stripped content
                                                                             const functionCallsIndex = strippedStreamingText.indexOf('<function_calls>');
                                                                             if (functionCallsIndex !== -1) {
@@ -837,8 +838,9 @@ export const ThreadContent: React.FC<ThreadContentProps> = ({
                                                                         // Strip <think> tags for playback mode assistant speech as well
                                                                         const strippedPlaybackStreamingText = rawPlaybackStreamingText.replace(/<think>((?:.|\n)*?)<\/think>/gi, '');
 
-                                                                        let detectedTag: string | null = null;
-                                                                        let tagStartIndex = -1;
+                                                                        // Corrected: Re-assign to existing variables, do not re-declare
+                                                                        detectedTag = null;
+                                                                        tagStartIndex = -1;
                                                                         if (strippedPlaybackStreamingText) { // Check on stripped content
                                                                             const functionCallsIndex = strippedPlaybackStreamingText.indexOf('<function_calls>');
                                                                             if (functionCallsIndex !== -1) {


### PR DESCRIPTION
Resolves a build failure caused by "Identifier 'detectedTag' has already been declared". The variables `detectedTag` and `tagStartIndex` were being re-declared using `let` within the same scope in two areas of `ThreadContent.tsx`:
1. In the logic for handling live streaming assistant content.
2. In the logic for handling streaming content in playback mode.

The fix changes these re-declarations to simple assignments, which was the original intent after processing stripped content.

This commit also includes the previous comprehensive changes for the enhanced animated reasoning view, as the build failure prevented their initial submission from being fully successful. The combined changes include:
- New `ReasoningView` with timer, expand/collapse, and sliding text animations.
- `useThinkingTimer` hook.
- Consolidated reasoning display logic in `ThreadContent.tsx` to use a single `ReasoningView` instance, sourcing content from a dedicated `reasoning` stream or `<think>` tags.
- Modifications to `renderMarkdownContent` to support this consolidation.