### PR TITLE
feat: Add extensive logging for reasoning and timer diagnostics

### DIFF
--- a/frontend/src/app/(dashboard)/projects/[projectId]/thread/[threadId]/page.tsx
+++ b/frontend/src/app/(dashboard)/projects/[projectId]/thread/[threadId]/page.tsx
@@ -242,6 +242,7 @@ export default function ThreadPage({
     threadId,
     setMessages,
   );
+  console.log(`[TIMER_DEBUG] page.tsx - Value from useAgentStream - isThinkingInProgress:`, isThinkingInProgress);
 
   const handleSubmitMessage = useCallback(
     async (
@@ -566,6 +567,9 @@ export default function ThreadPage({
     );
   }
 
+  // Log for isThinkingInProgress before rendering ThreadContent
+  console.log(`[TIMER_DEBUG] page.tsx - Passing to ThreadContent - isAgentActuallyThinking:`, isThinkingInProgress);
+
   return (
     <>
       <ThreadLayout
@@ -622,7 +626,7 @@ export default function ThreadPage({
           reasoning={reasoning}
           isAgentActuallyThinking={isThinkingInProgress} // New: Pass down the thinking status
         />
-
+      {/* Console log for isAgentActuallyThinking moved before the main return statement */}
         <div
           className={cn(
             "fixed bottom-0 z-10 bg-gradient-to-t from-background via-background/90 to-transparent px-4 pt-8 transition-all duration-200 ease-in-out",

--- a/frontend/src/components/thread/ReasoningView.tsx
+++ b/frontend/src/components/thread/ReasoningView.tsx
@@ -11,15 +11,21 @@ interface ReasoningViewProps {
 }
 
 export const ReasoningView: React.FC<ReasoningViewProps> = ({ content, isStreamingAgentActive }) => {
+  console.log(`[TIMER_DEBUG] ReasoningView - Received props.isStreamingAgentActive:`, isStreamingAgentActive);
   const formattedTime = useThinkingTimer(isStreamingAgentActive || false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [displayedThoughts, setDisplayedThoughts] = useState<string[]>([]);
 
+  // console.log(`[REASONING_DEBUG] ReasoningView - Props:`, { content, isStreamingAgentActive });
   useEffect(() => {
+    console.log(`[REASONING_DEBUG] ReasoningView - Received content prop:`, content); // Add this log
     if (content && content.trim() !== '') {
-      setDisplayedThoughts(content.split('\n'));
+      const thoughts = content.split('\n');
+      setDisplayedThoughts(thoughts);
+      console.log(`[REASONING_DEBUG] ReasoningView - Set displayedThoughts:`, thoughts); // Add this log
     } else {
-      setDisplayedThoughts([]); // Clear if content is empty
+      setDisplayedThoughts([]);
+      console.log(`[REASONING_DEBUG] ReasoningView - Cleared displayedThoughts`); // Add this log
     }
   }, [content]);
 
@@ -43,7 +49,7 @@ export const ReasoningView: React.FC<ReasoningViewProps> = ({ content, isStreami
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center">
           <span className="mr-2 thinking-icon">⚙️</span> {/* Existing animated icon */}
-          <span className="font-semibold">Pensamiento del Agente</span>
+          <span className="font-semibold">Agent Thoughts</span>
           {isStreamingAgentActive && (
             <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
               (Thinking for {formattedTime})

--- a/frontend/src/components/thread/content/ThreadContent.tsx
+++ b/frontend/src/components/thread/content/ThreadContent.tsx
@@ -317,6 +317,7 @@ export const ThreadContent: React.FC<ThreadContentProps> = ({
     reasoning, // This is props.reasoning from the dedicated stream
     isAgentActuallyThinking,
 }) => {
+    console.log(`[TIMER_DEBUG] ThreadContent - Received props.isAgentActuallyThinking:`, isAgentActuallyThinking);
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const messagesContainerRef = useRef<HTMLDivElement>(null);
     const latestMessageRef = useRef<HTMLDivElement>(null);
@@ -594,6 +595,17 @@ export const ThreadContent: React.FC<ThreadContentProps> = ({
                                                         const finalReasoningForView = reasoning || thinkTagContent;
                                                         // Use isAgentActuallyThinking for timer control, default to false if undefined
                                                         const timerControlFlag = isAgentActuallyThinking || false;
+                                                        console.log(`[TIMER_DEBUG] ThreadContent - Passing to ReasoningView as isStreamingAgentActive:`, timerControlFlag);
+
+
+                                                        // Add console logs for debugging reasoning display
+                                                        if (isLastGroup && (streamHookStatus === 'streaming' || streamHookStatus === 'connecting' || reasoning || thinkTagContent)) {
+                                                            console.log(`[REASONING_DEBUG] ThreadContent - PropsReasoning:`, reasoning);
+                                                            console.log(`[REASONING_DEBUG] ThreadContent - StreamingTextContent (raw for think extraction):`, contentForThinkExtraction);
+                                                            console.log(`[REASONING_DEBUG] ThreadContent - ExtractedThinkTagContent:`, thinkTagContent);
+                                                            console.log(`[REASONING_DEBUG] ThreadContent - FinalReasoningForView passed to ReasoningView:`, finalReasoningForView);
+                                                            // console.log(`[REASONING_DEBUG] ThreadContent - TimerControlFlag (isAgentActuallyThinking):`, timerControlFlag); // Already logged by TIMER_DEBUG
+                                                        }
 
                                                         // Render ReasoningView if there's dedicated reasoning, extracted think content, or if the agent is actively thinking (for timer).
                                                         if (finalReasoningForView || timerControlFlag) {

--- a/frontend/src/hooks/useAgentStream.ts
+++ b/frontend/src/hooks/useAgentStream.ts
@@ -151,6 +151,7 @@ export function useAgentStream(
       if (!isMountedRef.current) return;
 
       setIsThinkingInProgress(false); // Ensure thinking stops on any finalization
+      console.log(`[TIMER_DEBUG] useAgentStream.finalizeStream - Set isThinkingInProgress: false due to finalization status:`, finalStatus);
 
       const currentThreadId = threadIdRef.current; // Get current threadId from ref
       const currentSetMessages = setMessagesRef.current; // Get current setMessages from ref
@@ -310,9 +311,10 @@ export function useAgentStream(
           // to display the agent's thought process separately.
           // Accumulate reasoning content.
           const newReasoningChunk = parsedContent.content;
-          setReasoning(prevReasoning =>
-            (prevReasoning ? prevReasoning + '\n' : '') + newReasoningChunk
-          );
+          setReasoning(prevReasoning => {
+            console.log(`[REASONING_DEBUG] useAgentStream - PrevReasoning:`, prevReasoning, `NewChunk:`, newReasoningChunk); // Add this log
+            return (prevReasoning ? prevReasoning + '\n' : '') + newReasoningChunk;
+          });
           setIsThinkingInProgress(true); // Ensure thinking is marked as started when reasoning is received
           break;
         case 'assistant':
@@ -346,6 +348,7 @@ export function useAgentStream(
         case 'status':
           switch (parsedContent.status_type) {
             case 'thinking_completed': // New: Handle backend signal for thinking completion
+              console.log(`[TIMER_DEBUG] useAgentStream.handleStreamMessage - Received 'thinking_completed'. Setting isThinkingInProgress: false`);
               setIsThinkingInProgress(false);
               break;
             case 'tool_started':
@@ -551,6 +554,7 @@ export function useAgentStream(
   const startStreaming = useCallback(
     async (runId: string) => {
       if (!isMountedRef.current) return;
+      console.log(`[TIMER_DEBUG] useAgentStream.startStreaming - Called for runId:`, runId);
       console.log(
         `[useAgentStream] Received request to start streaming for ${runId}`,
       );
@@ -593,6 +597,7 @@ export function useAgentStream(
         }
 
         setIsThinkingInProgress(true); // Agent is confirmed running, start thinking timer
+        console.log(`[TIMER_DEBUG] useAgentStream.startStreaming - Set isThinkingInProgress: true`);
 
         // Agent is running, proceed to create the stream
         console.log(


### PR DESCRIPTION
Introduces detailed console logging to help diagnose issues with:
1. Live updates of my reasoning display. Logs are prefixed with `[REASONING_DEBUG]` and trace content flow from `useAgentStream` through `ThreadContent` to `ReasoningView`.
2. Accuracy of the "Thinking for..." timer. Logs are prefixed with `[TIMER_DEBUG]` and trace the `isThinkingInProgress` state and related props down to `ReasoningView`.

These logs are intended to be used to understand my current behavior and pinpoint failures in the live reasoning updates and timer control based on your console output.