### PR TITLE
feat: Implement enhanced XMLToolParser and integrate with ResponsePro…

### DIFF
--- a/backend/agentpress/xml_tool_parser.py
+++ b/backend/agentpress/xml_tool_parser.py
@@ -1,45 +1,78 @@
 import xml.etree.ElementTree as ET
 from typing import List, Optional
 
+# Ensure this import path is correct for your project structure
 from agentpress.tool import ToolCall
 
 
 class XMLToolParser:
-    """A parser for tool calls in XML format."""
+    """Un analizador para llamadas a herramientas en formato XML."""
 
     def parse(self, xml_string: str) -> Optional[List[ToolCall]]:
         """
-        Parses a string of XML and returns a list of ToolCall objects.
+        Analiza una cadena de XML y devuelve una lista de objetos ToolCall.
 
-        Args:
-            xml_string: The string of XML to parse.
-
-        Returns:
-            A list of ToolCall objects, or None if the string is not valid XML.
+        Este analizador es flexible y está diseñado para manejar múltiples formatos, incluyendo:
+        1. Formato simple: <nombre_herramienta><param>valor</param></nombre_herramienta>
+        2. Formato de invocación: <invoke name="nombre_herramienta"><parameter name="param">valor</parameter></invoke>
+        También maneja múltiples llamadas a herramientas, ya sea que estén o no envueltas en un elemento raíz.
         """
+        if not xml_string or not xml_string.strip():
+            return []
+
         try:
-            # Envolvemos el string XML con una raíz ficticia para manejar múltiples herramientas
-            # y la ausencia de un elemento raíz único.
-            # Esto hace que el parser sea mucho más flexible.
-            wrapped_xml_string = f"<dummy_root>{xml_string}</dummy_root>"
+            # Envolver el string en una raíz ficticia para manejar múltiples elementos raíz
+            wrapped_xml_string = f"<dummy_root>{xml_string.strip()}</dummy_root>"
             root = ET.fromstring(wrapped_xml_string)
 
             tool_calls = []
 
-            # El elemento raíz puede ser 'tools' o el ficticio 'dummy_root'
-            # Iteramos sobre sus hijos, que son las verdaderas llamadas a herramientas
-            for tool_element in root:
-                tool_name = tool_element.tag
-                tool_kwargs = {}
-                for param_element in tool_element:
-                    param_name = param_element.tag
-                    param_value = param_element.text or ""
-                    tool_kwargs[param_name] = param_value
-                tool_calls.append(ToolCall(tool_name, tool_kwargs))
+            # --- This part needs to be more robust for nested containers ---
+            temp_elements_to_check = list(root) # Start with children of dummy_root
+            final_tool_elements = []
+
+            while temp_elements_to_check:
+                element = temp_elements_to_check.pop(0) # Get first element
+                if element.tag.lower() in ['function_calls', 'tools', 'dummy_root']: # Added dummy_root just in case
+                    # If it's a known container, add its children to the front of the list to be checked
+                    temp_elements_to_check[0:0] = list(element)
+                else:
+                    # If it's not a known container, it's a potential tool element
+                    final_tool_elements.append(element)
+            # --- End of modified part ---
+
+            for element in final_tool_elements:
+                tool_name_val = None # Corrected variable name for clarity
+                tool_kwargs_val = {} # Corrected variable name for clarity
+
+                # Detectar el formato <invoke name="...">
+                if element.tag.lower() == 'invoke':
+                    tool_name_val = element.get('name')
+                    for param_element in element:
+                        if param_element.tag.lower() == 'parameter':
+                            param_name = param_element.get('name')
+                            param_value = param_element.text.strip() if param_element.text else ""
+                            if param_name:
+                                tool_kwargs_val[param_name] = param_value
+                # Manejar el formato simple <tool_name>...</tool_name>
+                else:
+                    tool_name_val = element.tag
+                    # Add attributes of the main tool tag as parameters
+                    for attr_name, attr_value in element.attrib.items():
+                        tool_kwargs_val[attr_name] = attr_value
+                    # Add children elements as parameters
+                    for param_element in element:
+                        param_name = param_element.tag
+                        param_value = param_element.text.strip() if param_element.text else ""
+                        tool_kwargs_val[param_name] = param_value
+
+                if tool_name_val:
+                    # Corrected instantiation to match ToolCall dataclass
+                    tool_calls.append(ToolCall(tool_name=tool_name_val, tool_kwargs=tool_kwargs_val))
 
             return tool_calls
         except ET.ParseError as e:
-            # Si incluso con el envoltorio falla, es un XML mal formado.
-            # Podríamos registrar el error para depuración.
-            print(f"Error al analizar XML: {e}")
+            # It's good practice to log the error or handle it appropriately
+            # For now, printing as in user's example
+            print(f"Error irrecuperable al analizar XML: {e}")
             return None

--- a/backend/tests/agentpress/test_xml_tool_parser.py
+++ b/backend/tests/agentpress/test_xml_tool_parser.py
@@ -2,7 +2,6 @@ import unittest
 from typing import List, Optional
 
 # Adjust the import path based on your project structure
-# Assuming agentpress is a top-level directory or accessible in PYTHONPATH
 from agentpress.xml_tool_parser import XMLToolParser
 from agentpress.tool import ToolCall
 
@@ -11,169 +10,178 @@ class TestXMLToolParser(unittest.TestCase):
     def setUp(self):
         self.parser = XMLToolParser()
 
+    def assertToolCallsEqual(self, result: Optional[List[ToolCall]], expected: List[ToolCall]):
+        self.assertIsNotNone(result, f"Expected tool calls, but got None. XML was likely malformed or parser had an issue.")
+        self.assertEqual(len(result), len(expected), f"Expected {len(expected)} tool calls, got {len(result)}. Result: {result}")
+        for i, res_call in enumerate(result):
+            exp_call = expected[i]
+            self.assertEqual(res_call.tool_name, exp_call.tool_name, f"Mismatch in tool_name for call {i}. Expected {exp_call.tool_name}, got {res_call.tool_name}")
+            self.assertEqual(res_call.tool_kwargs, exp_call.tool_kwargs, f"Mismatch in tool_kwargs for call {i}. For tool {exp_call.tool_name}, expected {exp_call.tool_kwargs}, got {res_call.tool_kwargs}")
+
     def test_parse_multiple_tools_no_root(self):
         xml_string = "<shell><command>ls</command></shell><web_search><query>Python</query></web_search>"
         expected_calls = [
-            ToolCall("shell", {"command": "ls"}),
-            ToolCall("web_search", {"query": "Python"})
+            ToolCall(tool_name="shell", tool_kwargs={"command": "ls"}),
+            ToolCall(tool_name="web_search", tool_kwargs={"query": "Python"})
         ]
         result = self.parser.parse(xml_string)
-        self.assertIsNotNone(result)
-        self.assertEqual(len(result), len(expected_calls))
-        for res_call, exp_call in zip(result, expected_calls):
-            self.assertEqual(res_call.tool_name, exp_call.tool_name)
-            self.assertEqual(res_call.tool_kwargs, exp_call.tool_kwargs)
+        self.assertToolCallsEqual(result, expected_calls)
 
     def test_parse_single_tool_no_root(self):
         xml_string = "<shell><command>echo \"Hola\"</command></shell>"
         expected_calls = [
-            ToolCall("shell", {"command": "echo \"Hola\""})
+            ToolCall(tool_name="shell", tool_kwargs={"command": "echo \"Hola\""})
         ]
         result = self.parser.parse(xml_string)
-        self.assertIsNotNone(result)
-        self.assertEqual(len(result), len(expected_calls))
-        self.assertEqual(result[0].tool_name, expected_calls[0].tool_name)
-        self.assertEqual(result[0].tool_kwargs, expected_calls[0].tool_kwargs)
+        self.assertToolCallsEqual(result, expected_calls)
 
-    def test_parse_original_format_with_tools_root(self):
-        xml_string = "<tools><shell><command>ls -l</command></shell></tools>"
-        # The dummy_root strategy means 'tools' itself is treated as a tool if not handled carefully.
-        # The provided parser iterates over children of dummy_root. If dummy_root's child is 'tools',
-        # then 'tools' children are the actual tools.
-        # The user-provided code for the parser is:
-        # for tool_element in root: # root is dummy_root
-        #     tool_name = tool_element.tag # this will be 'tools' in this case
-        # This needs adjustment in the parser OR the test.
-        # Let's assume the parser should handle if the first child of dummy_root is 'tools'.
+    def test_parse_invoke_format_single_tool(self):
+        xml_string = '<invoke name="create_file"><parameter name="file_path">test.txt</parameter><parameter name="content">Hello</parameter></invoke>'
+        expected_calls = [
+            ToolCall(tool_name="create_file", tool_kwargs={"file_path": "test.txt", "content": "Hello"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
 
-        # Corrected expectation based on the provided parser logic:
-        # The parser iterates children of <dummy_root>. If <tools> is the only child,
-        # then 'tools' is seen as one tool_element. Its children are not parsed as separate ToolCalls by current logic.
-        # To fix this, the parser would need to check if tool_element.tag == 'tools' and then iterate its children.
-        # OR, the agent should not send <tools> anymore if dummy_root is always added.
-        # Given the user's code, if <tools> is present, it will be parsed as ONE tool named "tools"
-        # and its children <shell> etc. will become its parameters. This is likely NOT the desired outcome.
+    def test_parse_invoke_format_multiple_tools(self):
+        xml_string = '<invoke name="tool1"><parameter name="p1">v1</parameter></invoke><invoke name="tool2"><parameter name="p2">v2</parameter></invoke>'
+        expected_calls = [
+            ToolCall(tool_name="tool1", tool_kwargs={"p1": "v1"}),
+            ToolCall(tool_name="tool2", tool_kwargs={"p2": "v2"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
 
-        # Let's test the current behavior of the provided parser:
-        # It will parse <tools> as a tool_name and <shell> as its parameter.
-        # This highlights a slight issue with the provided parser logic if <tools> is still used.
-        # The user's intention was "El elemento raíz puede ser 'tools' o el ficticio 'dummy_root'. Iteramos sobre sus hijos".
-        # This implies if dummy_root's child IS 'tools', then we should iterate children of 'tools'.
+    def test_parse_invoke_format_with_empty_param_value(self):
+        xml_string = '<invoke name="tool_empty_param"><parameter name="p1"></parameter></invoke>'
+        expected_calls = [
+            ToolCall(tool_name="tool_empty_param", tool_kwargs={"p1": ""})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
 
-        # For now, I will write the test according to how the provided parser code *actually* behaves.
-        # The parser: for tool_element in root: (root is dummy_root)
-        # If xml_string = "<tools><shell><command>ls -l</command></shell></tools>"
-        # wrapped_xml_string = "<dummy_root><tools><shell><command>ls -l</command></shell></tools></dummy_root>"
-        # tool_element will be the <tools> tag. tool_name = "tools"
-        # param_element will be <shell>. param_name = "shell", param_value will be an empty string
-        # because <shell> has a child <command>, not text. This needs refinement in parser.
+    def test_parse_with_function_calls_wrapper(self):
+        xml_string = "<function_calls><invoke name=\"tool_a\"><parameter name=\"arg1\">val1</parameter></invoke><shell><command>pwd</command></shell></function_calls>"
+        expected_calls = [
+            ToolCall(tool_name="tool_a", tool_kwargs={"arg1": "val1"}),
+            ToolCall(tool_name="shell", tool_kwargs={"command": "pwd"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
 
-        # Given the parser's current loop:
-        # for tool_element in root:
-        #     tool_name = tool_element.tag
-        #     tool_kwargs = {}
-        #     for param_element in tool_element: # These are children of tool_element
-        #         param_name = param_element.tag
-        #         param_value = param_element.text or ""
-        #         tool_kwargs[param_name] = param_value
-        #
-        # If input is <tools><shell><command>X</command></shell></tools>
-        # dummy_root has one child: <tools>
-        # tool_element = <tools>
-        # tool_name = "tools"
-        # param_element = <shell> (child of <tools>)
-        # param_name = "shell"
-        # param_value = <shell>'s text, which is empty/None because it has a child <command>
-        # So, tool_kwargs = {"shell": ""}
-        # Expected call: ToolCall("tools", {"shell": ""})
+    def test_parse_with_tools_wrapper(self):
+        xml_string = "<tools><shell><command>ls -l</command></shell><invoke name=\"tool_b\"><parameter name=\"arg_b\">val_b</parameter></invoke></tools>"
+        expected_calls = [
+            ToolCall(tool_name="shell", tool_kwargs={"command": "ls -l"}),
+            ToolCall(tool_name="tool_b", tool_kwargs={"arg_b": "val_b"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
 
-        # This is clearly not right for the <tools> case.
-        # The parser needs a small adjustment:
-        # if tool_element.tag == 'tools':
-        #   for sub_tool_element in tool_element:
-        #     # ... parse sub_tool_element
-        # else:
-        #   # ... parse tool_element as is
+    def test_parse_simple_tool_with_attributes(self):
+        xml_string = '<read-file path="doc.txt" check="true"></read-file>'
+        expected_calls = [
+            ToolCall(tool_name="read-file", tool_kwargs={"path": "doc.txt", "check": "true"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
 
-        # However, I must test the code AS GIVEN by the user first.
-        # The user's code will produce: ToolCall(tool_name='tools', tool_kwargs={'shell': ''})
-        # This is because param_element.text for <shell> is empty.
-        # If <shell> had text like <shell>value</shell>, then tool_kwargs would be {'shell': 'value'}
-
-        # Let's assume the user's code is intended to be used with XML that does NOT use <tools> anymore,
-        # OR the <tools> tag itself is a tool (unlikely).
-        # The most straightforward interpretation of "El elemento raíz puede ser 'tools' o el ficticio 'dummy_root'.
-        # Iteramos sobre sus hijos, que son las verdaderas llamadas a herramientas" is that
-        # if the first child of dummy_root is 'tools', then iterate over children of 'tools'.
-        # Otherwise, iterate children of 'dummy_root'.
-
-        # For now, I will write a test that *would* pass if the agent *stops* sending <tools>,
-        # and instead sends <shell>... directly, which the dummy_root handles.
-        # The user's examples for "Robustez Mejorada" all imply that <tools> is no longer the top-level sent by the agent.
-
-        # Test case if <tools> is NOT used, and multiple tools are direct children of dummy_root
-        xml_string_flat_multiple = "<shell><command>ls -l</command></shell><another_tool><param1>val1</param1></another_tool>"
-        result_flat_multiple = self.parser.parse(xml_string_flat_multiple)
-        self.assertIsNotNone(result_flat_multiple)
-        self.assertEqual(len(result_flat_multiple), 2)
-        self.assertEqual(result_flat_multiple[0].tool_name, "shell")
-        self.assertEqual(result_flat_multiple[0].tool_kwargs, {"command": "ls -l"})
-        self.assertEqual(result_flat_multiple[1].tool_name, "another_tool")
-        self.assertEqual(result_flat_multiple[1].tool_kwargs, {"param1": "val1"})
-
+    def test_parse_simple_tool_with_attributes_and_child_params(self):
+        xml_string = '<edit-file path="src.py"><content>new code</content><mode>overwrite</mode></edit-file>'
+        expected_calls = [
+            ToolCall(tool_name="edit-file", tool_kwargs={"path": "src.py", "content": "new code", "mode": "overwrite"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
 
     def test_parse_malformed_xml(self):
-        xml_string = "<shell><command>ls</command><shell>" # Malformed, unclosed command, misplaced shell
+        xml_string = "<shell><command>ls</command><shell>" # Malformed
         result = self.parser.parse(xml_string)
         self.assertIsNone(result, "Parser should return None for malformed XML")
 
     def test_parse_empty_string(self):
         xml_string = ""
-        # ET.fromstring("<dummy_root></dummy_root>") is valid, root is dummy_root, no children.
         result = self.parser.parse(xml_string)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 0, "Parser should return an empty list for an empty XML string")
 
-    def test_tool_call_with_no_parameters(self):
+    def test_tool_call_with_no_parameters_simple(self):
         xml_string = "<simple_tool></simple_tool>"
         expected_calls = [
-            ToolCall("simple_tool", {})
+            ToolCall(tool_name="simple_tool", tool_kwargs={})
         ]
         result = self.parser.parse(xml_string)
-        self.assertIsNotNone(result)
-        self.assertEqual(len(result), len(expected_calls))
-        self.assertEqual(result[0].tool_name, expected_calls[0].tool_name)
-        self.assertEqual(result[0].tool_kwargs, expected_calls[0].tool_kwargs)
+        self.assertToolCallsEqual(result, expected_calls)
 
-    def test_tool_call_with_empty_parameter_value(self):
+    def test_tool_call_with_no_parameters_invoke(self):
+        xml_string = "<invoke name=\"simple_tool_invoked\"></invoke>"
+        expected_calls = [
+            ToolCall(tool_name="simple_tool_invoked", tool_kwargs={})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
+
+    def test_tool_call_with_empty_parameter_value_simple(self):
         xml_string = "<tool_with_empty_param><param1></param1></tool_with_empty_param>"
         expected_calls = [
-            ToolCall("tool_with_empty_param", {"param1": ""})
+            ToolCall(tool_name="tool_with_empty_param", tool_kwargs={"param1": ""})
         ]
         result = self.parser.parse(xml_string)
-        self.assertIsNotNone(result)
-        self.assertEqual(len(result), len(expected_calls))
-        self.assertEqual(result[0].tool_name, expected_calls[0].tool_name)
-        self.assertEqual(result[0].tool_kwargs, expected_calls[0].tool_kwargs)
+        self.assertToolCallsEqual(result, expected_calls)
 
-    def test_tool_call_with_mixed_content_parameters(self):
-        # The current parser only extracts param_element.text. It doesn't handle mixed content
-        # or nested structures within a parameter value itself.
-        # Example: <param1>some text <child>more text</child></param1> -> param_value would be "some text "
+    def test_tool_call_with_mixed_content_parameters_simple(self):
         xml_string = "<complex_param_tool><param_name>text <nested_tag>stuff</nested_tag> more text</param_name></complex_param_tool>"
-        # According to the parser logic:
-        # tool_name = "complex_param_tool"
-        # param_element = <param_name>
-        # param_name = "param_name"
-        # param_value = param_element.text = "text " (text before the first child)
         expected_calls = [
-            ToolCall("complex_param_tool", {"param_name": "text "})
+            ToolCall(tool_name="complex_param_tool", tool_kwargs={"param_name": "text"})
         ]
         result = self.parser.parse(xml_string)
-        self.assertIsNotNone(result)
-        self.assertEqual(len(result), len(expected_calls))
-        self.assertEqual(result[0].tool_name, expected_calls[0].tool_name)
-        self.assertEqual(result[0].tool_kwargs, expected_calls[0].tool_kwargs)
+        self.assertToolCallsEqual(result, expected_calls)
+
+    def test_parse_invoke_with_no_parameters_self_closing(self):
+        xml_string = '<invoke name="no_param_invoke_tool" />' # Self-closing style
+        expected_calls = [
+            ToolCall(tool_name="no_param_invoke_tool", tool_kwargs={})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
+
+    def test_parse_mixed_invoke_and_simple_formats(self):
+        xml_string = '<invoke name="tool_one"><parameter name="p1">val1</parameter></invoke><simple_tool><param_s>val_s</param_s></simple_tool>'
+        expected_calls = [
+            ToolCall(tool_name="tool_one", tool_kwargs={"p1": "val1"}),
+            ToolCall(tool_name="simple_tool", tool_kwargs={"param_s": "val_s"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
+
+    def test_parse_deeply_nested_containers(self):
+        xml_string = "<tools><function_calls><invoke name=\"deep_tool\"><parameter name=\"p\">v</parameter></invoke></function_calls></tools>"
+        # The parser should flatten this due to the <dummy_root> wrapping (added by parser) and iteration logic.
+        # Parser logic: if element.tag.lower() in ['function_calls', 'tools']: final_tool_elements.extend(element)
+        # So, dummy_root -> tools -> function_calls -> invoke. It should correctly find 'invoke'.
+        expected_calls = [
+            ToolCall(tool_name="deep_tool", tool_kwargs={"p": "v"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
+
+    def test_parse_attributes_on_invoke_tag_are_ignored(self):
+        # Attributes on <invoke> itself (other than 'name') should be ignored by current logic.
+        xml_string = '<invoke name="ignored_attr_invoke" extra_attr="ignore_me"><parameter name="p1">v1</parameter></invoke>'
+        expected_calls = [
+            ToolCall(tool_name="ignored_attr_invoke", tool_kwargs={"p1": "v1"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
+
+    def test_parse_attributes_on_parameter_tag_are_ignored(self):
+        # Attributes on <parameter> itself (other than 'name') should be ignored.
+        xml_string = '<invoke name="ignored_param_attr"><parameter name="p1" other_attr="boo">v1</parameter></invoke>'
+        expected_calls = [
+            ToolCall(tool_name="ignored_param_attr", tool_kwargs={"p1": "v1"})
+        ]
+        result = self.parser.parse(xml_string)
+        self.assertToolCallsEqual(result, expected_calls)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…cessor

This commit introduces a significantly more robust and flexible XMLToolParser, incorporating your feedback and addressing several parsing challenges. The ResponseProcessor has been updated to integrate with this new parser, and comprehensive tests have been added.

Key changes include:

1.  **`backend/agentpress/xml_tool_parser.py`**:
    *   Replaced with new parser logic that intelligently handles various XML
        formats for tool calls.
    *   It now correctly parses:
        *   Simple format: `<tool_name><param>value</param></tool_name>` (including attributes on `tool_name` tag).
        *   Invoke format: `<invoke name="tool_name"><parameter name="param">value</parameter></invoke>`.
        *   Inputs wrapped in container tags like `<function_calls>...</function_calls>` or `<tools>...</tools>`, including nested containers.
    *   Uses a `<dummy_root>` wrapping strategy for all inputs to handle
        multiple top-level tool calls or calls without any root element.
    *   Instantiates `ToolCall` objects using the correct field names
        (`tool_name`, `tool_kwargs`).

2.  **`backend/agentpress/tool.py`**:
    *   Verified that the `ToolCall` dataclass (`tool_name: str, tool_kwargs: Dict[str, Any]`)
        is correctly defined. This was confirmed as part of a previous step that fixed test dependencies.

3.  **`backend/tests/agentpress/test_xml_tool_parser.py`**:
    *   Updated and significantly enhanced the test suite for `XMLToolParser`.
    *   Includes 20 test cases covering simple formats, the new invoke format,
        container tags, attribute parsing, empty/malformed inputs, and mixed
        content scenarios.
    *   All tests pass, confirming the robustness of the new parser. Some fixes
        to the parser's handling of nested containers were made during testing.

4.  **`backend/agentpress/response_processor.py`**:
    *   Updated `XMLToolParser` instantiation in `__init__` to `XMLToolParser()`
        (removed deprecated `strict_mode`).
    *   Changed the method call in `_parse_xml_tool_call` from
        `self.xml_parser.parse_content()` to `self.xml_parser.parse()` to align
        with the updated parser.
    *   Adjusted `_parse_xml_tool_call` to correctly initialize `parsing_details`
        and handle `raw_xml` when the new parser path for
        `<function_calls><invoke...>` is taken, preventing potential
        AttributeErrors.

These changes collectively make my ability to understand and prepare tool calls from XML much more reliable, addressing a core aspect of the initial issue concerning effective tool use.