### PR TITLE
fix: Correct DeepResearchToolUpdated parameters and schema for LLM

### DIFF
--- a/backend/agent/tools/deep_research_tool_updated.py
+++ b/backend/agent/tools/deep_research_tool_updated.py
@@ -153,6 +153,40 @@ class DeepResearchToolUpdated(Tool):
 
         return self._sandbox
 
+    @openapi_schema({
+        "type": "function",
+        "function": {
+            "name": "deep-search",
+            "description": "Perform deep research on a topic by searching multiple sources, analyzing content, and synthesizing information.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "topic": {
+                        "type": "string",
+                        "description": "The research topic or question to investigate in detail."
+                    },
+                    "depth": {
+                        "type": "string",
+                        "description": "The depth of research: 'basic' (quick overview), 'standard' (comprehensive), or 'deep' (exhaustive). Default: standard.",
+                        "enum": ["basic", "standard", "deep"],
+                        "default": "standard"
+                    },
+                    "sources": {
+                        "type": "integer",
+                        "description": "Minimum number of sources to include. Default: 5.",
+                        "default": 5
+                    },
+                    "format": {
+                        "type": "string",
+                        "description": "Format of the final report: 'markdown', 'pdf', or 'html'. Default: markdown.",
+                        "enum": ["markdown", "pdf", "html"],
+                        "default": "markdown"
+                    }
+                },
+                "required": ["topic"]
+            }
+        }
+    })
     @xml_schema(
         tag_name="deep-search",
         # Parameters are passed as a Pydantic model 'parameters',


### PR DESCRIPTION
This commit resolves a Pydantic validation error where the LLM attempted to use an unsupported 'year_filter' parameter with the DeepResearchToolUpdated (deep-search) tool.

The following changes were made to `deep_research_tool_updated.py`:
1.  The `run` method was corrected to return a single `ToolResult` object instead of a list of one element. Error returns were also standardized. This fixed a downstream `AttributeError: 'list' object has no attribute 'success'` in the ResponseProcessor.
2.  The `@openapi_schema` decorator was removed from the `DeepResearchToolUpdatedOutput` Pydantic class, as Pydantic models used for output schemas typically do not require this decorator.
3.  An explicit `@openapi_schema` decorator was added to the `run` method of `DeepResearchToolUpdated`. This schema accurately defines the tool's expected parameters (`topic`, `depth`, `sources`, `format`) based on the `ActualDeepResearchToolParameters` Pydantic model.

These changes ensure that the tool's interface is correctly exposed and described to the LLM via the system prompt, which should prevent the LLM from trying to use undefined parameters and resolve the Pydantic `extra_forbidden` validation error.