### PR TITLE
Okay, I've made a fix to ensure `DeepResearchToolUpdatedOutput` is a …

### DIFF
--- a/backend/agent/tools/deep_research_tool_updated.py
+++ b/backend/agent/tools/deep_research_tool_updated.py
@@ -43,7 +43,7 @@ class _Decorated_DeepResearchToolUpdatedParameters:
     class Config:
         extra = "forbid"
 
-class DeepResearchToolUpdatedOutput:
+class DeepResearchToolUpdatedOutput(BaseModel):
     """
     Output for the DeepResearchToolUpdated.
     """


### PR DESCRIPTION
…Pydantic model.

I modified `DeepResearchToolUpdatedOutput` in
`backend/agent/tools/deep_research_tool_updated.py` to inherit from `pydantic.BaseModel`.

This change allows the class to be instantiated with keyword arguments, which resolves the error:
`TypeError: DeepResearchToolUpdatedOutput() takes no arguments`. This error was happening when `DeepResearchToolUpdated` tried to return its structured output.