### PR TITLE
feat: Add extensive debugging for file creation

### DIFF
--- a/backend/agent/tools/sb_files_tool.py
+++ b/backend/agent/tools/sb_files_tool.py
@@ -121,7 +121,7 @@ class SandboxFilesTool(SandboxToolsBase):
     )
     async def create_file(self, file_path: str, file_contents: str) -> ToolResult:
         try:
-            logger.info(f"Attempting to create file: {file_path} in project {self.project_id}")
+            logger.info(f"SandboxFilesTool: Attempting to create file. Project ID: {self.project_id}, File path: {file_path}")
             # Ensure sandbox is initialized
             await self._ensure_sandbox()
             
@@ -131,7 +131,9 @@ class SandboxFilesTool(SandboxToolsBase):
                 return self.fail_response(f"File '{file_path}' already exists. Use update_file to modify existing files.")
             
             # Write the file content
+            logger.info(f"SandboxFilesTool: Writing to sandbox path: {full_path}")
             await self.sandbox.fs.upload_file(full_path, file_contents.encode('utf-8'))
+            logger.info(f"SandboxFilesTool: Successfully wrote to sandbox path: {full_path}")
             
             # If it reaches here, it's a success.
             final_message = f"File '{file_path}' created successfully."
@@ -148,6 +150,7 @@ class SandboxFilesTool(SandboxToolsBase):
             
             return self.success_response(final_message)
         except Exception as e:
+            logger.error(f"SandboxFilesTool: Error creating file {file_path}. Exception: {str(e)}")
             return self.fail_response(f"Error creating file '{file_path}': {str(e)}")
 
     @openapi_schema({

--- a/backend/agentpress/response_processor.py
+++ b/backend/agentpress/response_processor.py
@@ -1347,6 +1347,11 @@ class ResponseProcessor:
             openapi_tool_info = None
             xml_tool_info = None
 
+            # Conditional logging for file-related tools
+            file_related_tools = ["create_file", "create_document_template", "create_report"]
+            if original_function_name in file_related_tools:
+                logger.info(f"Attempting to execute file-related tool: {original_function_name} with arguments: {arguments}")
+
             if xml_tag_name_from_call:
                 # Attempt to find the tool using the XML tag name registry first
                 xml_tool_info = self.tool_registry.get_xml_tool(xml_tag_name_from_call)


### PR DESCRIPTION
I've added detailed logging to various parts of my process to help diagnose issues related to file creation, particularly for Markdown files and plans.

Key changes:
- I've added logs to trace the invocation of file creation related actions.
- I've added logs in my file creation method to show the file path, project ID, sandbox path, and success/failure of the upload operation.
- For document generation:
    - I've added logs for template name, type, project ID, and sandbox upload details.
    - I've added logs for report title, output path, format, project ID, temporary file uploads, and conversion steps.
    - I've added detailed logs for directory creation commands, including stdout/stderr, to debug directory creation issues.

These logs will provide you with better visibility into my file creation process.