### PR TITLE
Fix: Correct Supabase client import in api-client.ts

### DIFF
--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,7 +1,7 @@
-import { getSupabaseClient } from './supabase/client'; // Changed import
+import { createClient } from './supabase/client'; // Changed import name
 // Removed: import { PUBLIC_API_PREFIX } from '$env/static/public';
 
-const supabase = getSupabaseClient(); // Call the function to get the client
+const supabase = createClient(); // Changed initialization call
 const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || '/api'; // Redefined API_PREFIX
 
 export interface InitiateAgentPayload {


### PR DESCRIPTION
I updated `frontend/src/lib/api-client.ts` to correctly import and initialize the Supabase client.
- I changed the import from `getSupabaseClient` to `createClient` from `'./supabase/client'`.
- I updated the client instantiation to call `createClient()` instead of `getSupabaseClient()`.

This resolves the previous build error: "Type error: Module './supabase/client' has no exported member 'getSupabaseClient'".