### PR TITLE
Fix: Add runtime check for AgentRun properties in api-enhanced.ts

### DIFF
--- a/frontend/src/lib/api-enhanced.ts
+++ b/frontend/src/lib/api-enhanced.ts
@@ -349,7 +349,7 @@ export const agentApi = {
   },
 
   async getStatus(agentRunId: string): Promise<AgentRun | null> {
-    const result = await backendApi.get(
+    const result = await backendApi.get<AgentRun>(
       `/agent/${agentRunId}/status`,
       {
         errorContext: { operation: 'get agent status', resource: 'AI assistant status' },
@@ -357,7 +357,10 @@ export const agentApi = {
       }
     );
 
-    return result.data || null;
+    if (result.data && result.data.id && result.data.thread_id && result.data.status && result.data.started_at) {
+      return result.data;
+    }
+    return null;
   },
 
   async getRuns(threadId: string): Promise<AgentRun[]> {


### PR DESCRIPTION
I modified the `agentApi.getStatus` method in `frontend/src/lib/api-enhanced.ts`. The method now performs a runtime check to ensure that `result.data` (from `backendApi.get<AgentRun>`) contains key required properties of the `AgentRun` type (id, thread_id, status, started_at) before returning it. If these properties are absent (e.g., if `result.data` is an empty object `{}`), the method now returns `null`.

This resolves the TypeScript error: "Type error: Type '{}' is missing the following properties from type 'AgentRun': id, thread_id, status, started_at, and 3 more." by ensuring that structurally incomplete data is not returned as `AgentRun`.