### PR TITLE
Fix: Correct typing in agentApi.getRuns of api-enhanced.ts

### DIFF
--- a/frontend/src/lib/api-enhanced.ts
+++ b/frontend/src/lib/api-enhanced.ts
@@ -364,14 +364,14 @@ export const agentApi = {
   },
 
   async getRuns(threadId: string): Promise<AgentRun[]> {
-    const result = await backendApi.get(
+    const result = await backendApi.get<AgentRun[]>(
       `/thread/${threadId}/agent/runs`,
       {
         errorContext: { operation: 'load agent runs', resource: 'conversation history' },
       }
     );
 
-    return result.data || [];
+    return Array.isArray(result.data) ? result.data : [];
   },
 };
 


### PR DESCRIPTION
- Added an explicit generic type argument `<AgentRun[]>` to the `backendApi.get` call within the `agentApi.getRuns` method in `frontend/src/lib/api-enhanced.ts`.
- Updated the return statement to `Array.isArray(result.data) ? result.data : []` for robust handling of the data type.

This ensures that TypeScript correctly infers the type of `result.data` as `AgentRun[] | null` and that an array is always returned, resolving the error: "Type error: Type '{}' is missing the following properties from type 'AgentRun[]': length, pop, push, concat, and 35 more."