### PR TITLE
Fix: Correct typing in billingApi.getSubscription

### DIFF
--- a/frontend/src/lib/api-enhanced.ts
+++ b/frontend/src/lib/api-enhanced.ts
@@ -377,14 +377,20 @@ export const agentApi = {
 
 export const billingApi = {
   async getSubscription(): Promise<SubscriptionStatus | null> {
-    const result = await backendApi.get(
+    const result = await backendApi.get<SubscriptionStatus>(
       '/billing/subscription',
       {
         errorContext: { operation: 'load subscription', resource: 'billing information' },
       }
     );
 
-    return result.data || null;
+    if (result.data &&
+        typeof result.data.status === 'string' &&
+        typeof result.data.cancel_at_period_end === 'boolean' &&
+        typeof result.data.has_schedule === 'boolean') {
+      return result.data;
+    }
+    return null;
   },
 
   async checkStatus(): Promise<BillingStatusResponse | null> {


### PR DESCRIPTION
- Added an explicit generic type argument `<SubscriptionStatus>` to the `backendApi.get` call within the `billingApi.getSubscription` method in `frontend/src/lib/api-enhanced.ts`.
- Updated the return statement to perform a runtime check for key properties of `SubscriptionStatus` before returning the data. If properties are missing or of the wrong type, `null` is returned.

This ensures that TypeScript correctly infers the type of `result.data` as `SubscriptionStatus | null` and that structurally incomplete data is handled gracefully, resolving the error: "Type error: Type '{}' is missing the following properties from type 'SubscriptionStatus': status, cancel_at_period_end, has_schedule".